### PR TITLE
Add NERSC config files

### DIFF
--- a/NERSC/cori_and_edison/README.md
+++ b/NERSC/cori_and_edison/README.md
@@ -1,0 +1,4 @@
+# NERSC Specific Configs
+The configs contained here are packages.yaml and the compilers.yaml for
+both Edison and Cori. Since they both share the same Cray PE, the config 
+**should** work on both machines. 

--- a/NERSC/cori_and_edison/compilers.yaml
+++ b/NERSC/cori_and_edison/compilers.yaml
@@ -1,0 +1,284 @@
+compilers:
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-cray
+    - cce/8.6.0
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: cce@8.6.0
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-cray
+    - cce/8.6.2
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: cce@8.6.2
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-cray
+    - cce/8.6.5
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: cce@8.6.5
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-gnu
+    - gcc/4.9.3
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: gcc@4.9.3
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-gnu
+    - gcc/6.1.0
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: gcc@6.1.0
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-gnu
+    - gcc/7.1.0
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: gcc@7.1.0
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-gnu
+    - gcc/7.3.0
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: gcc@7.3.0
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-gnu
+    - gcc/5.3.0
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: gcc@5.3.0
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-gnu
+    - gcc/6.3.0
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: gcc@6.3.0
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-gnu
+    - gcc/7.2.0
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: gcc@7.2.0
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-intel
+    - intel/17.0.2.174
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: intel@17.0.2.174
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-intel
+    - intel/18.0.1.163
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: intel@18.0.1.163
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-intel
+    - intel/18.0.2.199
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: intel@18.0.2.199
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-intel
+    - intel/16.0.3.210
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: intel@16.0.3.210
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-intel
+    - intel/17.0.3.191
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: intel@17.0.3.191
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-intel
+    - intel/17.0.1.132
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: intel@17.0.1.132
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-intel
+    - intel/18.0.0.128
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: intel@18.0.0.128
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-pgi
+    - pgi/2017
+    operating_system: cnl6
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    spec: pgi@2017
+    target: any
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: sles12
+    paths:
+      cc: /usr/bin/gcc-4.8
+      cxx: /usr/bin/g++-4.8
+      f77: null
+      fc: null
+    spec: gcc@4.8
+    target: x86_64

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -1,0 +1,97 @@
+# NERSC config used as of 10/26/2018
+packages:
+    all:
+        compiler: [intel@18.0.1.163, gcc@7.1.0, cce@8.6.2]
+        providers:
+            mpi: [mpich, openmpi]
+            mkl: [intel-mkl]
+            blas: [intel-mkl, cray-libsci]
+            scalapack: [intel-mkl, cray-libsci]
+            pkgconfig: [pkg-config]
+    pkg-config:
+        buildable: false
+        paths:
+            pkg-config@0.28: /usr
+    cmake:
+        buildable: false
+        paths:
+            cmake@3.5.2: /usr
+    mpich:
+        buildable: false
+        modules:
+            mpich@7.6.2%gcc: cray-mpich
+            mpich@7.6.2%intel: cray-mpich
+            mpich@7.6.2%cce: cray-mpich
+    intel-mkl:
+        buildable: false
+        paths:
+            intel-mkl@2018.1.163%intel: /opt/intel
+            intel-mkl@2018.1.163%gcc: /opt/intel
+            intel-mkl@2018.1.163%cce: /opt/intel
+    fftw:
+        buildable: false
+        modules:
+            fftw@3.3.6.2%gcc+openmp: cray-fftw
+            fftw@3.3.6.2%intel+openmp: cray-fftw
+            fftw@3.3.6.2%cce+openmp: cray-fftw
+    hdf5:
+        buildable: false
+        modules:
+            hdf5%intel~mpi+hl: cray-hdf5
+            hdf5%gcc~mpi+hl: cray-hdf5
+            hdf5%cce~mpi+hl: cray-hdf5
+            hdf5%intel+mpi+hl: cray-hdf5-parallel
+            hdf5%gcc+mpi+hl: cray-hdf5-parallel
+            hdf5%cce+mpi+hl: cray-hdf5-parallel
+    petsc:
+         buildable: false
+         modules:
+            petsc@3.7.6.0%gcc~complex~int64 : cray-petsc
+            petsc@3.7.6.0%intel~complex~int64 : cray-petsc
+            petsc@3.7.6.0%cce~complex~int64: cray-petsc
+            petsc@3.7.6.0%gcc+complex~int64 : cray-petsc-complex
+            petsc@3.7.6.0%intel+complex~int64 : cray-petsc-complex
+            petsc@3.7.6.0%cce+complex~int64: cray-petsc-complex
+            petsc@3.7.6.0%gcc~complex+int64 : cray-petsc-64
+            petsc@3.7.6.0%intel~complex+int64: cray-petsc-64
+            petsc@3.7.6.0%cce~complex+int64: cray-petsc-64
+            petsc@3.7.6.0%gcc+complex+int64 : cray-petsc-complex-64
+            petsc@3.7.6.0%intel+complex+int64 : cray-petsc-complex-64
+            petsc@3.7.6.0%cce+complex+int64: cray-petsc-complex-64
+    cray-libsci:
+        buildable: false
+        modules:
+            cray-libsci@16.07.1%gcc: cray-libsci
+            cray-libsci@16.07.1%intel: cray-libsci
+            cray-libsci@16.07.1%cce: cray-libsci
+    netcdf:
+        buildable: false
+        modules:
+            netcdf@4.4.1.1.3%gcc+parallel-netcdf+mpi: cray-netcdf-hdf5parallel
+            netcdf@4.4.1.1.3%intel+parallel-netcdf+mpi: cray-netcdf-hdf5parallel
+            netcdf@4.4.1.1.3%cce+parallel-netcdf+mpi: cray-netcdf-hdf5parallel
+            netcdf@4.4.1.1.3%gcc~parallel-netcdf~mpi: cray-netcdf
+            netcdf@4.4.1.1.3%intel~parallel-netcdf~mpi: cray-netcdf
+            netcdf@4.4.1.1.3%cce~parallel-netcdf~mpi: cray-netcdf
+    netcdf-fortran:
+        buildable: false
+        modules:
+            netcdf-fortran@4.4.1.1.3%intel: cray-netcdf-hdf5parallel
+            netcdf-fortran@4.4.1.1.3%cce: cray-netcdf-hdf5parallel
+            netcdf-fortran@4.4.1.1.3%gcc: cray-netcdf-hdf5parallel
+    papi:
+        buildable: false
+        modules:
+            papi@5.5.1.3%gcc: papi
+            papi@5.5.1.3%intel: papi
+            papi@5.5.1.3%cce: papi
+    trilinos:
+        buildable: false
+        modules:
+            trilinos@12.10.1.1%gcc: cray-trilinos
+            trilinos@12.10.1.1%intel: cray-trilinos
+            trilinos@12.10.1.1%cce: cray-trilinos
+    perl:
+        compiler: [intel@17.0.3.191, gcc, cce]
+    python:
+        variants: +shared


### PR DESCRIPTION
Includes packages.yaml and compilers.yaml. In theory, the config should
work for both Edison and Cori.