### PR TITLE
Update NERSC system packages

### DIFF
--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -97,6 +97,12 @@ packages:
     cmake:
         paths:
              cmake@3.5.2: /usr
+        modules:
+             cmake@3.3.2:  cmake/3.3.2
+             cmake@3.5.2:  cmake/3.5.2
+             cmake@3.8.2:  cmake/3.8.2
+             cmake@3.11.4: cmake/3.11.4
+             cmake@3.14.0: cmake/3.14.0
     curl:
         paths:
              curl@7.37.0: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -146,3 +146,7 @@ packages:
         buildable: false
         paths:
              xz@5.0.5: /usr
+    readline:
+        buildable: false
+        paths:
+             readline@6.3: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -35,9 +35,15 @@ packages:
     fftw:
         buildable: false
         modules:
-            fftw@3.3.8.1%gcc+openmp: cray-fftw
-            fftw@3.3.8.1%intel+openmp: cray-fftw
-            fftw@3.3.8.1%cce+openmp: cray-fftw
+            fftw@3.3.6.3%gcc+openmp:   cray-fftw/3.3.6.3
+            fftw@3.3.6.3%intel+openmp: cray-fftw/3.3.6.3
+            fftw@3.3.6.3%cce+openmp:   cray-fftw/3.3.6.3
+            fftw@3.3.8.1%gcc+openmp:   cray-fftw/3.3.8.1
+            fftw@3.3.8.1%intel+openmp: cray-fftw/3.3.8.1
+            fftw@3.3.8.1%cce+openmp:   cray-fftw/3.3.8.1
+            fftw@3.3.8.2%gcc+openmp:   cray-fftw/3.3.8.2
+            fftw@3.3.8.2%intel+openmp: cray-fftw/3.3.8.2
+            fftw@3.3.8.2%cce+openmp:   cray-fftw/3.3.8.2
     hdf5:
         buildable: false
         modules:

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -11,9 +11,18 @@ packages:
     mpich:
         buildable: false
         modules:
-            mpich@7.7.3%gcc: cray-mpich
-            mpich@7.7.3%intel: cray-mpich
-            mpich@7.7.3%cce: cray-mpich
+            mpich@7.7.0%gcc:   cray-mpich/7.7.0
+            mpich@7.7.0%intel: cray-mpich/7.7.0
+            mpich@7.7.0%cce:   cray-mpich/7.7.0
+            mpich@7.7.3%gcc:   cray-mpich/7.7.3
+            mpich@7.7.3%intel: cray-mpich/7.7.3
+            mpich@7.7.3%cce:   cray-mpich/7.7.3
+            mpich@7.7.4%gcc:   cray-mpich/7.7.4
+            mpich@7.7.4%intel: cray-mpich/7.7.4
+            mpich@7.7.4%cce:   cray-mpich/7.7.4
+            mpich@7.7.6%gcc:   cray-mpich/7.7.6
+            mpich@7.7.6%intel: cray-mpich/7.7.6
+            mpich@7.7.6%cce:   cray-mpich/7.7.6
     intel-mkl:
         buildable: false
         paths:

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -82,3 +82,7 @@ packages:
             trilinos@12.12.1.1%gcc: cray-trilinos
             trilinos@12.12.1.1%intel: cray-trilinos
             trilinos@12.12.1.1%cce: cray-trilinos
+    openssl:
+        buildable: false
+        paths:
+             openssl@1.0.2j-fips: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -101,9 +101,18 @@ packages:
     cray-libsci:
         buildable: false
         modules:
-            cray-libsci@18.07.1%gcc: cray-libsci
-            cray-libsci@18.07.1%intel: cray-libsci
-            cray-libsci@18.07.1%cce: cray-libsci
+            cray-libsci@18.03.1%gcc:   cray-libsci/18.03.1
+            cray-libsci@18.03.1%intel: cray-libsci/18.03.1
+            cray-libsci@18.03.1%cce:   cray-libsci/18.03.1
+            cray-libsci@18.07.1%gcc:   cray-libsci/18.07.1
+            cray-libsci@18.07.1%intel: cray-libsci/18.07.1
+            cray-libsci@18.07.1%cce:   cray-libsci/18.07.1
+            cray-libsci@18.12.1%gcc:   cray-libsci/18.12.1
+            cray-libsci@18.12.1%intel: cray-libsci/18.12.1
+            cray-libsci@18.12.1%cce:   cray-libsci/18.12.1
+            cray-libsci@19.02.1%gcc:   cray-libsci/19.02.1
+            cray-libsci@19.02.1%intel: cray-libsci/19.02.1
+            cray-libsci@19.02.1%cce:   cray-libsci/19.02.1
     netcdf:
         buildable: false
         modules:

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -94,3 +94,7 @@ packages:
         buildable: false
         paths:
              automake@1.13.4: /usr
+    bzip2:
+        buildable: false
+        paths:
+             bzip2@1.0.6: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -110,3 +110,7 @@ packages:
         buildable: false
         paths:
              diffutils@3.3: /usr
+    gawk:
+        buildable: false
+        paths:
+             gawk@4.1.0: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -90,3 +90,7 @@ packages:
         buildable: false
         paths:
              autoconf@2.69: /usr
+    automake:
+        buildable: false
+        paths:
+             automake@1.13.4: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -150,3 +150,7 @@ packages:
         buildable: false
         paths:
              readline@6.3: /usr
+    zlib:
+        buildable: false
+        paths:
+             zlib@1.2.8: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -102,3 +102,7 @@ packages:
         buildable: false
         paths:
              cmake@3.5.2: /usr
+    curl:
+        buildable: false
+        paths:
+             curl@7.37.0: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -154,3 +154,7 @@ packages:
         buildable: false
         paths:
              zlib@1.2.8: /usr
+    python:
+        buildable: false
+        paths:
+             python@2.7.13: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -83,78 +83,59 @@ packages:
             trilinos@12.12.1.1%intel: cray-trilinos
             trilinos@12.12.1.1%cce: cray-trilinos
     openssl:
-        buildable: false
         paths:
              openssl@1.0.2j-fips: /usr
     autoconf:
-        buildable: false
         paths:
              autoconf@2.69: /usr
     automake:
-        buildable: false
         paths:
              automake@1.13.4: /usr
     bzip2:
-        buildable: false
         paths:
              bzip2@1.0.6: /usr
     cmake:
-        buildable: false
         paths:
              cmake@3.5.2: /usr
     curl:
-        buildable: false
         paths:
              curl@7.37.0: /usr
     diffutils:
-        buildable: false
         paths:
              diffutils@3.3: /usr
     gawk:
-        buildable: false
         paths:
              gawk@4.1.0: /usr
     gettext:
-        buildable: false
         paths:
              gettext@0.19.2: /usr
     libtool:
-        buildable: false
         paths:
              libtool@2.4.2: /usr
     lz4:
-        buildable: false
         paths:
              lz4@1.7.4: /usr
     m4:
-        buildable: false
         paths:
              m4@1.4.16: /usr
     perl:
-        buildable: false
         paths:
              perl@5.18.2: /usr
     pkg-config:
-        buildable: false
         paths:
              pkg-config@0.28: /usr
     tar:
-        buildable: false
         paths:
              tar@1.27.1: /bin
     xz:
-        buildable: false
         paths:
              xz@5.0.5: /usr
     readline:
-        buildable: false
         paths:
              readline@6.3: /usr
     zlib:
-        buildable: false
         paths:
              zlib@1.2.8: /usr
     python:
-        buildable: false
         paths:
              python@2.7.13: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -116,18 +116,27 @@ packages:
     netcdf:
         buildable: false
         modules:
-            netcdf@4.6.1.3%gcc+parallel-netcdf+mpi: cray-netcdf-hdf5parallel
-            netcdf@4.6.1.3%intel+parallel-netcdf+mpi: cray-netcdf-hdf5parallel
-            netcdf@4.6.1.3%cce+parallel-netcdf+mpi: cray-netcdf-hdf5parallel
-            netcdf@4.6.1.3%gcc~parallel-netcdf~mpi: cray-netcdf
-            netcdf@4.6.1.3%intel~parallel-netcdf~mpi: cray-netcdf
-            netcdf@4.6.1.3%cce~parallel-netcdf~mpi: cray-netcdf
+            netcdf@4.4.1.1.6%gcc+parallel-netcdf+mpi:   cray-netcdf-hdf5parallel/4.4.1.1.6
+            netcdf@4.4.1.1.6%intel+parallel-netcdf+mpi: cray-netcdf-hdf5parallel/4.4.1.1.6
+            netcdf@4.4.1.1.6%cce+parallel-netcdf+mpi:   cray-netcdf-hdf5parallel/4.4.1.1.6
+            netcdf@4.6.1.3%gcc+parallel-netcdf+mpi:     cray-netcdf-hdf5parallel/4.6.1.3
+            netcdf@4.6.1.3%intel+parallel-netcdf+mpi:   cray-netcdf-hdf5parallel/4.6.1.3
+            netcdf@4.6.1.3%cce+parallel-netcdf+mpi:     cray-netcdf-hdf5parallel/4.6.1.3
+            netcdf@4.4.1.1.6%gcc~parallel-netcdf~mpi:   cray-netcdf/4.4.1.1.6
+            netcdf@4.4.1.1.6%intel~parallel-netcdf~mpi: cray-netcdf/4.4.1.1.6
+            netcdf@4.4.1.1.6%cce~parallel-netcdf~mpi:   cray-netcdf/4.4.1.1.6
+            netcdf@4.6.1.3%gcc~parallel-netcdf~mpi:     cray-netcdf/4.6.1.3
+            netcdf@4.6.1.3%intel~parallel-netcdf~mpi:   cray-netcdf/4.6.1.3
+            netcdf@4.6.1.3%cce~parallel-netcdf~mpi:     cray-netcdf/4.6.1.3
     netcdf-fortran:
         buildable: false
         modules:
-            netcdf-fortran@4.6.1.3%intel: cray-netcdf-hdf5parallel
-            netcdf-fortran@4.6.1.3%cce: cray-netcdf-hdf5parallel
-            netcdf-fortran@4.6.1.3%gcc: cray-netcdf-hdf5parallel
+            netcdf-fortran@4.4.1.1.6%intel: cray-netcdf-hdf5parallel/4.4.1.1.6
+            netcdf-fortran@4.4.1.1.6%cce:   cray-netcdf-hdf5parallel/4.4.1.1.6
+            netcdf-fortran@4.4.1.1.6%gcc:   cray-netcdf-hdf5parallel/4.4.1.1.6
+            netcdf-fortran@4.6.1.3%intel:   cray-netcdf-hdf5parallel/4.6.1.3
+            netcdf-fortran@4.6.1.3%cce:     cray-netcdf-hdf5parallel/4.6.1.3
+            netcdf-fortran@4.6.1.3%gcc:     cray-netcdf-hdf5parallel/4.6.1.3
     papi:
         buildable: false
         modules:

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -138,3 +138,7 @@ packages:
         buildable: false
         paths:
              pkg-config@0.28: /usr
+    tar:
+        buildable: false
+        paths:
+             tar@1.27.1: /bin

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -86,3 +86,7 @@ packages:
         buildable: false
         paths:
              openssl@1.0.2j-fips: /usr
+    autoconf:
+        buildable: false
+        paths:
+             autoconf@2.69: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -126,3 +126,7 @@ packages:
         buildable: false
         paths:
              lz4@1.7.4: /usr
+    m4:
+        buildable: false
+        paths:
+             m4@1.4.16: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -130,3 +130,7 @@ packages:
         buildable: false
         paths:
              m4@1.4.16: /usr
+    perl:
+        buildable: false
+        paths:
+             perl@5.18.2: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -106,3 +106,7 @@ packages:
         buildable: false
         paths:
              curl@7.37.0: /usr
+    diffutils:
+        buildable: false
+        paths:
+             diffutils@3.3: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -62,18 +62,42 @@ packages:
     petsc:
          buildable: false
          modules:
-            petsc@3.8.4.0%gcc~complex~int64 : cray-petsc/3.8.4.0
-            petsc@3.8.4.0%intel~complex~int64 : cray-petsc/3.8.4.0
-            petsc@3.8.4.0%cce~complex~int64: cray-petsc/3.8.4.0
-            petsc@3.8.4.0%gcc+complex~int64 : cray-petsc-complex/3.8.4.0
-            petsc@3.8.4.0%intel+complex~int64 : cray-petsc-complex/3.8.4.0
-            petsc@3.8.4.0%cce+complex~int64: cray-petsc-complex/3.8.4.0
-            petsc@3.8.4.0%gcc~complex+int64 : cray-petsc-64/3.8.4.0
-            petsc@3.8.4.0%intel~complex+int64: cray-petsc-64/3.8.4.0
-            petsc@3.8.4.0%cce~complex+int64: cray-petsc-64/3.8.4.0
-            petsc@3.8.4.0%gcc+complex+int64 : cray-petsc-complex-64/3.8.4.0
-            petsc@3.8.4.0%intel+complex+int64 : cray-petsc-complex-64/3.8.4.0
-            petsc@3.8.4.0%cce+complex+int64: cray-petsc-complex-64/3.8.4.0
+            petsc@3.7.6.2%gcc~complex~int64:    cray-petsc/3.7.6.2
+            petsc@3.7.6.2%intel~complex~int64:  cray-petsc/3.7.6.2
+            petsc@3.7.6.2%cce~complex~int64:    cray-petsc/3.7.6.2
+            petsc@3.8.4.0%gcc~complex~int64:    cray-petsc/3.8.4.0
+            petsc@3.8.4.0%intel~complex~int64:  cray-petsc/3.8.4.0
+            petsc@3.8.4.0%cce~complex~int64:    cray-petsc/3.8.4.0
+            petsc@3.9.3.0%gcc~complex~int64:    cray-petsc/3.9.3.0
+            petsc@3.9.3.0%intel~complex~int64:  cray-petsc/3.9.3.0
+            petsc@3.9.3.0%cce~complex~int64:    cray-petsc/3.9.3.0
+            petsc@3.7.6.2%gcc+complex~int64:    cray-petsc-complex/3.7.6.2
+            petsc@3.7.6.2%intel+complex~int64:  cray-petsc-complex/3.7.6.2
+            petsc@3.7.6.2%cce+complex~int64:    cray-petsc-complex/3.7.6.2
+            petsc@3.8.4.0%gcc+complex~int64:    cray-petsc-complex/3.8.4.0
+            petsc@3.8.4.0%intel+complex~int64:  cray-petsc-complex/3.8.4.0
+            petsc@3.8.4.0%cce+complex~int64:    cray-petsc-complex/3.8.4.0
+            petsc@3.9.3.0%gcc+complex~int64:    cray-petsc-complex/3.9.3.0
+            petsc@3.9.3.0%intel+complex~int64:  cray-petsc-complex/3.9.3.0
+            petsc@3.9.3.0%cce+complex~int64:    cray-petsc-complex/3.9.3.0
+            petsc@3.7.6.2%gcc~complex+int64:    cray-petsc-64/3.7.6.2
+            petsc@3.7.6.2%intel~complex+int64:  cray-petsc-64/3.7.6.2
+            petsc@3.7.6.2%cce~complex+int64:    cray-petsc-64/3.7.6.2
+            petsc@3.8.4.0%gcc~complex+int64:    cray-petsc-64/3.8.4.0
+            petsc@3.8.4.0%intel~complex+int64:  cray-petsc-64/3.8.4.0
+            petsc@3.8.4.0%cce~complex+int64:    cray-petsc-64/3.8.4.0
+            petsc@3.9.3.0%gcc~complex+int64:    cray-petsc-64/3.9.3.0
+            petsc@3.9.3.0%intel~complex+int64:  cray-petsc-64/3.9.3.0
+            petsc@3.9.3.0%cce~complex+int64:    cray-petsc-64/3.9.3.0
+            petsc@3.7.6.2%gcc+complex+int64:    cray-petsc-complex-64/3.7.6.2
+            petsc@3.7.6.2%intel+complex+int64:  cray-petsc-complex-64/3.7.6.2
+            petsc@3.7.6.2%cce+complex+int64:    cray-petsc-complex-64/3.7.6.2
+            petsc@3.8.4.0%gcc+complex+int64:    cray-petsc-complex-64/3.8.4.0
+            petsc@3.8.4.0%intel+complex+int64:  cray-petsc-complex-64/3.8.4.0
+            petsc@3.8.4.0%cce+complex+int64:    cray-petsc-complex-64/3.8.4.0
+            petsc@3.9.3.0%gcc+complex+int64:    cray-petsc-complex-64/3.9.3.0
+            petsc@3.9.3.0%intel+complex+int64:  cray-petsc-complex-64/3.9.3.0
+            petsc@3.9.3.0%cce+complex+int64:    cray-petsc-complex-64/3.9.3.0
     cray-libsci:
         buildable: false
         modules:

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -17,9 +17,12 @@ packages:
     intel-mkl:
         buildable: false
         paths:
-            intel-mkl@2018.1.163%intel: /opt/intel
-            intel-mkl@2018.1.163%gcc: /opt/intel
-            intel-mkl@2018.1.163%cce: /opt/intel
+            intel-mkl@2018.1.163%intel+ilp64 threads=tbb:  /opt/intel
+            intel-mkl@2018.1.163%gcc+ilp64 threads=tbb:    /opt/intel
+            intel-mkl@2018.1.163%cce+ilp64 threads=tbb:    /opt/intel
+            intel-mkl@2018.1.163%intel~ilp64 threads=none: /opt/intel
+            intel-mkl@2018.1.163%gcc~ilp64 threads=none:   /opt/intel
+            intel-mkl@2018.1.163%cce~ilp64 threads=none:   /opt/intel
     fftw:
         buildable: false
         modules:

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -142,3 +142,7 @@ packages:
         buildable: false
         paths:
              tar@1.27.1: /bin
+    xz:
+        buildable: false
+        paths:
+             xz@5.0.5: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -98,3 +98,7 @@ packages:
         buildable: false
         paths:
              bzip2@1.0.6: /usr
+    cmake:
+        buildable: false
+        paths:
+             cmake@3.5.2: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -134,3 +134,7 @@ packages:
         buildable: false
         paths:
              perl@5.18.2: /usr
+    pkg-config:
+        buildable: false
+        paths:
+             pkg-config@0.28: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -122,3 +122,7 @@ packages:
         buildable: false
         paths:
              libtool@2.4.2: /usr
+    lz4:
+        buildable: false
+        paths:
+             lz4@1.7.4: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -118,3 +118,7 @@ packages:
         buildable: false
         paths:
              gettext@0.19.2: /usr
+    libtool:
+        buildable: false
+        paths:
+             libtool@2.4.2: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -114,3 +114,7 @@ packages:
         buildable: false
         paths:
              gawk@4.1.0: /usr
+    gettext:
+        buildable: false
+        paths:
+             gettext@0.19.2: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -150,3 +150,9 @@ packages:
              python@2.7.15: python/2.7-anaconda-5.2
              python@3.5.2:  python/3.5-anaconda
              python@3.6.8:  python/3.6-anaconda-5.2
+
+    boost:
+        modules:
+             boost@1.67.0: boost/1.67.0
+             boost@1.69.0: boost/1.69.0
+             boost@1.70.0: boost/1.70.0

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -155,9 +155,12 @@ packages:
     trilinos:
         buildable: false
         modules:
-            trilinos@12.12.1.1%gcc: cray-trilinos
-            trilinos@12.12.1.1%intel: cray-trilinos
-            trilinos@12.12.1.1%cce: cray-trilinos
+            trilinos@12.10.1.2%gcc:   cray-trilinos/12.10.1.2
+            trilinos@12.10.1.2%intel: cray-trilinos/12.10.1.2
+            trilinos@12.10.1.2%cce:   cray-trilinos/12.10.1.2
+            trilinos@12.12.1.1%gcc:   cray-trilinos/12.12.1.1
+            trilinos@12.12.1.1%intel: cray-trilinos/12.12.1.1
+            trilinos@12.12.1.1%cce:   cray-trilinos/12.12.1.1
     openssl:
         paths:
              openssl@1.0.2j-fips: /usr

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -139,3 +139,8 @@ packages:
     python:
         paths:
              python@2.7.13: /usr
+        modules:
+             python@2.7.13: python/2.7-anaconda-4.4
+             python@2.7.15: python/2.7-anaconda-5.2
+             python@3.5.2:  python/3.5-anaconda
+             python@3.6.8:  python/3.6-anaconda-5.2

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -140,9 +140,18 @@ packages:
     papi:
         buildable: false
         modules:
-            papi@5.6.0.3%gcc: papi
-            papi@5.6.0.3%intel: papi
-            papi@5.6.0.3%cce: papi
+            papi@5.5.1.4%gcc:   papi/5.5.1.4
+            papi@5.5.1.4%intel: papi/5.5.1.4
+            papi@5.5.1.4%cce:   papi/5.5.1.4
+            papi@5.6.0.3%gcc:   papi/5.6.0.3
+            papi@5.6.0.3%intel: papi/5.6.0.3
+            papi@5.6.0.3%cce:   papi/5.6.0.3
+            papi@5.6.0.5%gcc:   papi/5.6.0.5
+            papi@5.6.0.5%intel: papi/5.6.0.5
+            papi@5.6.0.5%cce:   papi/5.6.0.5
+            papi@5.6.0.6%gcc:   papi/5.6.0.6
+            papi@5.6.0.6%intel: papi/5.6.0.6
+            papi@5.6.0.6%cce:   papi/5.6.0.6
     trilinos:
         buildable: false
         modules:

--- a/NERSC/cori_and_edison/packages.yaml
+++ b/NERSC/cori_and_edison/packages.yaml
@@ -47,11 +47,18 @@ packages:
     hdf5:
         buildable: false
         modules:
-            hdf5@1.10.2.0%intel~mpi+hl: cray-hdf5
-            hdf5@1.10.2.0%gcc~mpi+hl: cray-hdf5
-            hdf5@1.10.2.0%cce~mpi+hl: cray-hdf5
-            hdf5@1.10.2.0%intel+mpi+hl: cray-hdf5-parallel
-            hdf5@1.10.2.0%gcc+mpi+hl: cray-hdf5-parallel
+            hdf5@1.10.1.1%intel~mpi+hl: cray-hdf5/1.10.1.1
+            hdf5@1.10.1.1%gcc~mpi+hl:   cray-hdf5/1.10.1.1
+            hdf5@1.10.1.1%cce~mpi+hl:   cray-hdf5/1.10.1.1
+            hdf5@1.10.2.0%intel~mpi+hl: cray-hdf5/1.10.2.0
+            hdf5@1.10.2.0%gcc~mpi+hl:   cray-hdf5/1.10.2.0
+            hdf5@1.10.2.0%cce~mpi+hl:   cray-hdf5/1.10.2.0
+            hdf5@1.10.1.1%intel+mpi+hl: cray-hdf5-parallel/1.10.1.1
+            hdf5@1.10.1.1%gcc+mpi+hl:   cray-hdf5-parallel/1.10.1.1
+            hdf5@1.10.1.1%cce+mpi+hl:   cray-hdf5-parallel/1.10.1.1
+            hdf5@1.10.2.0%intel+mpi+hl: cray-hdf5-parallel/1.10.2.0
+            hdf5@1.10.2.0%gcc+mpi+hl:   cray-hdf5-parallel/1.10.2.0
+            hdf5@1.10.2.0%cce+mpi+hl:   cray-hdf5-parallel/1.10.2.0
     petsc:
          buildable: false
          modules:


### PR DESCRIPTION
Cray's OS provides many standard packages that Spack does not need to build from source. Adding these to the NERSC `packages.yaml` speeds up builds of many different packages.