### PR TITLE
Add spack configs for Spock and Summit

### DIFF
--- a/OLCF/spock/e4s-21.05.txt
+++ b/OLCF/spock/e4s-21.05.txt
@@ -1,200 +1,832 @@
-adios2@2.7.1%cce@12.0.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
-adios2@2.7.1%cce@12.0.1 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
-adios2@2.7.1%gcc@10.2.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
-adios2@2.7.1%gcc@10.3.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
-aml@0.1.0%cce@12.0.0
-aml@0.1.0%cce@12.0.1
-aml@0.1.0%gcc@10.2.0
-aml@0.1.0%gcc@10.3.0
-arborx@1.0%cce@12.0.0 ~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
-arborx@1.0%cce@12.0.1 ~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
-arborx@1.0%gcc@10.2.0 ~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
-arborx@1.0%gcc@10.3.0 ~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
-argobots@1.1%cce@12.0.0 ~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none
-argobots@1.1%cce@12.0.1 ~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none
-argobots@1.1%gcc@10.2.0 ~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none
-argobots@1.1%gcc@10.3.0 ~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none
-bolt@2.0%cce@12.0.0 ~ipo build_type=RelWithDebInfo
-bolt@2.0%cce@12.0.1 ~ipo build_type=RelWithDebInfo
-bolt@2.0%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
-bolt@2.0%gcc@10.3.0 ~ipo build_type=RelWithDebInfo
-cabana@0.3.0%cce@12.0.0 ~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
-cabana@0.3.0%cce@12.0.1 ~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
-cabana@0.3.0%gcc@10.2.0 ~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
-cabana@0.3.0%gcc@10.3.0 ~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
-caliper@2.5.0%gcc@10.2.0 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
-caliper@2.5.0%gcc@10.3.0 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
-ccache@4.3%gcc@7.5.0 ~ipo build_type=RelWithDebInfo
-chai@2.3.0%cce@12.0.0 ~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
-chai@2.3.0%cce@12.0.1 ~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
-chai@2.3.0%gcc@10.2.0 ~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
-chai@2.3.0%gcc@10.3.0 ~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
-cmake@3.20.2%gcc@7.5.0 ~doc+ncurses+openssl+ownlibs~qt build_type=Release
-cmake@3.21.2-dev%gcc@7.5.0 ~doc+ncurses+openssl+ownlibs~qt build_type=Release
-conduit@0.7.2%cce@12.0.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
-conduit@0.7.2%cce@12.0.1 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
-conduit@0.7.2%gcc@10.2.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
-conduit@0.7.2%gcc@10.3.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
-darshan-util@3.3.0%cce@12.0.0 ~apmpi~apxc~bzip2+shared
-darshan-util@3.3.0%cce@12.0.1 ~apmpi~apxc~bzip2+shared
-darshan-util@3.3.0%gcc@7.5.0 ~apmpi~apxc~bzip2+shared
-darshan-util@3.3.0%gcc@10.2.0 ~apmpi~apxc~bzip2+shared
-darshan-util@3.3.0%gcc@10.3.0 ~apmpi~apxc~bzip2+shared
-dyninst@11.0.0%gcc@10.2.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-dyninst@11.0.0%gcc@10.3.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-emacs@27.2%gcc@7.5.0 +X~native~tls toolkit=gtk
-faodel@1.1906.1%cce@12.0.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
-faodel@1.1906.1%cce@12.0.1 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
-faodel@1.1906.1%gcc@10.2.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
-faodel@1.1906.1%gcc@10.3.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
-flecsi@1.4%cce@12.0.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
-flecsi@1.4%cce@12.0.1 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
-flecsi@1.4%gcc@10.2.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
-flecsi@1.4%gcc@10.3.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
-flit@2.1.0%cce@12.0.0
-flit@2.1.0%cce@12.0.1
-flit@2.1.0%gcc@10.2.0
-flit@2.1.0%gcc@10.3.0
-gasnet@2020.3.0%cce@12.0.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
-gasnet@2020.3.0%cce@12.0.1 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
-gasnet@2020.3.0%gcc@10.2.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
-gasnet@2020.3.0%gcc@10.3.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
-gdb@10.2%gcc@7.5.0 ~gold~ld~lto+python~quad~source-highlight~tui+xz patches=0b73f4c573768130ab59fa218cfc352d1db9678423ce787012e46e589154745c
-git@2.31.1%gcc@7.5.0 +man+nls+perl~svn~tcltk
-globalarrays@5.8%cce@12.0.0 ~scalapack armci=mpi-ts
-globalarrays@5.8%cce@12.0.1 ~scalapack armci=mpi-ts
-globalarrays@5.8%gcc@10.2.0 ~scalapack armci=mpi-ts
-globalarrays@5.8%gcc@10.3.0 ~scalapack armci=mpi-ts
-gmp@6.2.1%cce@12.0.0
-gmp@6.2.1%cce@12.0.1
-gmp@6.2.1%gcc@10.2.0
-gmp@6.2.1%gcc@10.3.0
-gnupg@2.2.19%gcc@7.5.0
-gnuplot@5.2.8%gcc@7.5.0 +X+cairo+gd+libcerf~pbm~qt~wx patches=ad89f23815fd925889ae78009ba22e6f9e4b12fea389280040cef519deafb052
-go@1.16.4%gcc@7.5.0
-googletest@1.11.0%gcc@7.5.0 ~gmock~ipo+pthreads+shared build_type=RelWithDebInfo
-gotcha@1.0.3%cce@12.0.0 ~ipo~test build_type=RelWithDebInfo
-gotcha@1.0.3%cce@12.0.1 ~ipo~test build_type=RelWithDebInfo
-gotcha@1.0.3%gcc@10.2.0 ~ipo~test build_type=RelWithDebInfo
-gotcha@1.0.3%gcc@10.3.0 ~ipo~test build_type=RelWithDebInfo
-hdf5@1.10.7%cce@12.0.1 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%gcc@10.3.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-heffte@2.0.0%cce@12.0.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
-heffte@2.0.0%cce@12.0.1 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
-heffte@2.0.0%gcc@10.2.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
-heffte@2.0.0%gcc@10.3.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
-hpctoolkit@2021.03.01%gcc@10.2.0 ~all-static~cray~cuda~mpi+papi~rocm
-hpctoolkit@2021.03.01%gcc@10.3.0 ~all-static~cray~cuda~mpi+papi~rocm
-hpx@1.6.0%cce@12.0.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.6.0%cce@12.0.1 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.6.0%gcc@10.2.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.6.0%gcc@10.3.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-htop@3.0.2%gcc@7.5.0 +unicode
-hypre@2.20.0%cce@12.0.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%cce@12.0.1 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%gcc@10.2.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%gcc@10.3.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-imagemagick@7.0.8-7%gcc@7.5.0
-kokkos@3.4.00%cce@12.0.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14
-kokkos@3.4.00%cce@12.0.1 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14
-kokkos@3.4.00%gcc@10.2.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14
-kokkos@3.4.00%gcc@10.3.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14
-kokkos@3.4.00%cce@12.0.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14
-kokkos@3.4.00%cce@12.0.1 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14
-kokkos@3.4.00%gcc@10.2.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14
-kokkos@3.4.00%gcc@10.3.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14
-kokkos-kernels@3.2.00%cce@12.0.0 ~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
-kokkos-kernels@3.2.00%cce@12.0.1 ~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
-kokkos-kernels@3.2.00%gcc@10.2.0 ~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
-kokkos-kernels@3.2.00%gcc@10.3.0 ~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
-legion@21.03.0%cce@12.0.0 ~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-legion@21.03.0%cce@12.0.1 ~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-legion@21.03.0%gcc@10.2.0 ~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-legion@21.03.0%gcc@10.3.0 ~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-libpng@1.2.57%gcc@7.5.0
-libquo@1.3.1%cce@12.0.0
-libquo@1.3.1%cce@12.0.1
-libquo@1.3.1%gcc@10.2.0
-libquo@1.3.1%gcc@10.3.0
-libzmq@4.3.3%gcc@7.5.0 ~drafts+libsodium
-magma@2.6.1%cce@12.0.0 ~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
-magma@2.6.1%cce@12.0.1 ~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
-magma@2.6.1%gcc@10.2.0 ~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
-magma@2.6.1%gcc@10.3.0 ~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
-mercurial@5.8%gcc@7.5.0
-mercury@2.0.1%cce@12.0.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.1%cce@12.0.1 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.1%gcc@10.2.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.1%gcc@10.3.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mfem@4.2.0%cce@12.0.0 ~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto
-mfem@4.2.0%cce@12.0.1 ~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto
-mfem@4.2.0%gcc@10.2.0 ~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto
-mfem@4.2.0%gcc@10.3.0 ~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto
-nano@4.9%gcc@7.5.0
-ninja@1.10.2%gcc@10.2.0
-omega-h@9.32.5%cce@12.0.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
-omega-h@9.32.5%cce@12.0.1 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
-omega-h@9.32.5%gcc@10.2.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
-omega-h@9.32.5%gcc@10.3.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
-openpmd-api@0.13.4%cce@12.0.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.4%cce@12.0.1 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.4%gcc@10.2.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.4%gcc@10.3.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-papi@6.0.0.1%cce@12.0.0 ~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools patches=b6d6caa8c66a6495a24f32ba444e46f61e85083146dfa73ee3c8cf91fcfb4458
-papi@6.0.0.1%cce@12.0.1 ~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools patches=b6d6caa8c66a6495a24f32ba444e46f61e85083146dfa73ee3c8cf91fcfb4458
-papi@6.0.0.1%gcc@7.5.0 ~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools
-papyrus@1.0.1%cce@12.0.0 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.1%cce@12.0.1 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.1%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.1%gcc@10.3.0 ~ipo build_type=RelWithDebInfo
-pdt@3.25.1%cce@12.0.0 ~pic patches=113fca02f74cc49dc1add0f617a4bada116a999a1664598380e5e7652c8c231a
-pdt@3.25.1%cce@12.0.1 ~pic patches=113fca02f74cc49dc1add0f617a4bada116a999a1664598380e5e7652c8c231a
-pdt@3.25.1%gcc@10.2.0 ~pic
-pdt@3.25.1%gcc@10.3.0 ~pic
-petsc@3.15.0%gcc@10.2.0 ~X+batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.15.0%gcc@10.3.0 ~X+batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-precice@2.2.1%gcc@10.2.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
-precice@2.2.1%gcc@10.3.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
-pumi@2.2.5%cce@12.0.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.5%cce@12.0.1 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.5%gcc@10.2.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.5%gcc@10.3.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-qthreads@1.16%cce@12.0.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.16%cce@12.0.1 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.16%gcc@10.2.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.16%gcc@10.3.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-raja@0.13.0%cce@12.0.0 ~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
-raja@0.13.0%cce@12.0.1 ~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
-raja@0.13.0%gcc@10.2.0 ~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
-raja@0.13.0%gcc@10.3.0 ~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
-screen@4.8.0%gcc@7.5.0  patches=755de623439b654453801dbbb09cce0f3f889a12ad1a060bf57147d5b2b5c295
-slate@2021.05.02%gcc@10.2.0 ~cuda~ipo+mpi+openmp+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
-slate@2021.05.02%gcc@10.3.0 ~cuda~ipo+mpi+openmp+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
-slepc@3.15.0%gcc@10.2.0 +arpack~blopex
-slepc@3.15.0%gcc@10.3.0 +arpack~blopex
-stc@0.9.0%cce@12.0.0
-stc@0.9.0%cce@12.0.1
-stc@0.9.0%gcc@10.2.0
-stc@0.9.0%gcc@10.3.0
-subversion@1.14.0%gcc@7.5.0 ~perl+serf
-superlu@5.2.1%cce@12.0.0 +pic
-superlu@5.2.1%cce@12.0.1 +pic
-superlu@5.2.1%gcc@10.2.0 +pic
-superlu@5.2.1%gcc@10.3.0 +pic
-swig@4.0.2%gcc@10.2.0
-swig@4.0.2-fortran%cce@12.0.0
-swig@4.0.2-fortran%cce@12.0.1
-swig@4.0.2-fortran%gcc@10.2.0
-swig@4.0.2-fortran%gcc@10.3.0
-tasmanian@7.5%cce@12.0.0 ~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none
-tasmanian@7.5%cce@12.0.1 ~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none
-tasmanian@7.5%gcc@10.2.0 ~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none
-tasmanian@7.5%gcc@10.3.0 ~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none
-tmux@3.1b%gcc@7.5.0
-umap@2.1.0%cce@12.0.0 ~ipo~logging~tests build_type=RelWithDebInfo
-umap@2.1.0%cce@12.0.1 ~ipo~logging~tests build_type=RelWithDebInfo
-umap@2.1.0%gcc@10.2.0 ~ipo~logging~tests build_type=RelWithDebInfo
-umap@2.1.0%gcc@10.3.0 ~ipo~logging~tests build_type=RelWithDebInfo
-umpire@4.1.2%gcc@10.2.0 +c~cuda~deviceconst+examples~fortran~ipo~numa~openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none
-vim@8.2.2541%gcc@7.5.0 ~big~cscope~gui~huge~lua~normal~perl~python~ruby~small~tiny~x
-wget@1.21%gcc@7.5.0 ~libpsl~pcre~python+zlib ssl=openssl
+adiak,0.2.1,gcc@10.2.0,~ipo+mpi+shared build_type=RelWithDebInfo,cray-sles15-zen2
+adiak,0.2.1,gcc@10.3.0,~ipo+mpi+shared build_type=RelWithDebInfo,cray-sles15-zen2
+adios2,2.7.1,cce@12.0.0,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,cray-sles15-zen2
+adios2,2.7.1,cce@12.0.1,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,cray-sles15-zen2
+adios2,2.7.1,gcc@10.2.0,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,cray-sles15-zen2
+adios2,2.7.1,gcc@10.3.0,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,cray-sles15-zen2
+adlbx,1.0.0,cce@12.0.0,,cray-sles15-zen2
+adlbx,1.0.0,cce@12.0.1,,cray-sles15-zen2
+adlbx,1.0.0,gcc@10.2.0,,cray-sles15-zen2
+adlbx,1.0.0,gcc@10.3.0,,cray-sles15-zen2
+aml,0.1.0,cce@12.0.0,,cray-sles15-zen2
+aml,0.1.0,cce@12.0.1,,cray-sles15-zen2
+aml,0.1.0,gcc@10.2.0,,cray-sles15-zen2
+aml,0.1.0,gcc@10.3.0,,cray-sles15-zen2
+ant,1.10.7,cce@12.0.0,,cray-sles15-zen2
+ant,1.10.7,cce@12.0.1,,cray-sles15-zen2
+ant,1.10.7,gcc@10.2.0,,cray-sles15-zen2
+ant,1.10.7,gcc@10.3.0,,cray-sles15-zen2
+apr,1.7.0,gcc@7.5.0, patches=a4128488c546646b4a585c3d49706675b1c016139dd61bdd153fb3151bbcb12c,linux-sles15-x86_64
+apr-util,1.6.1,gcc@7.5.0,+crypto~gdbm~odbc~pgsql~sqlite,linux-sles15-x86_64
+arborx,1.0,cce@12.0.0,~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo,cray-sles15-zen2
+arborx,1.0,cce@12.0.1,~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo,cray-sles15-zen2
+arborx,1.0,gcc@10.2.0,~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo,cray-sles15-zen2
+arborx,1.0,gcc@10.3.0,~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo,cray-sles15-zen2
+argobots,1.1,cce@12.0.0,~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none,cray-sles15-zen2
+argobots,1.1,cce@12.0.1,~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none,cray-sles15-zen2
+argobots,1.1,gcc@10.2.0,~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none,cray-sles15-zen2
+argobots,1.1,gcc@10.3.0,~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none,cray-sles15-zen2
+arpack-ng,3.8.0,gcc@10.2.0,+mpi+shared,cray-sles15-zen2
+arpack-ng,3.8.0,gcc@10.3.0,+mpi+shared,cray-sles15-zen2
+at-spi2-atk,2.38.0,gcc@7.5.0,~strip buildtype=debugoptimized default_library=shared,linux-sles15-x86_64
+at-spi2-core,2.40.1,gcc@7.5.0,~strip buildtype=debugoptimized default_library=shared,linux-sles15-x86_64
+atk,2.36.0,gcc@7.5.0,,linux-sles15-x86_64
+autoconf,2.69,cce@12.0.0,,cray-sles15-zen2
+autoconf,2.69,cce@12.0.1,,cray-sles15-zen2
+autoconf,2.69,gcc@7.5.0,,linux-sles15-x86_64
+autoconf,2.69,gcc@10.2.0,,cray-sles15-zen2
+autoconf,2.69,gcc@10.3.0,,cray-sles15-zen2
+autoconf-archive,2019.01.06,cce@12.0.0,,cray-sles15-zen2
+autoconf-archive,2019.01.06,cce@12.0.1,,cray-sles15-zen2
+autoconf-archive,2019.01.06,gcc@7.5.0,,linux-sles15-x86_64
+autoconf-archive,2019.01.06,gcc@10.2.0,,cray-sles15-zen2
+autoconf-archive,2019.01.06,gcc@10.3.0,,cray-sles15-zen2
+automake,1.16.3,cce@12.0.0,,cray-sles15-zen2
+automake,1.16.3,cce@12.0.1,,cray-sles15-zen2
+automake,1.16.3,gcc@7.5.0,,linux-sles15-x86_64
+automake,1.16.3,gcc@10.2.0,,cray-sles15-zen2
+automake,1.16.3,gcc@10.3.0,,cray-sles15-zen2
+bdftopcf,1.0.5,gcc@7.5.0,,linux-sles15-x86_64
+berkeley-db,18.1.40,cce@12.0.0,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,cray-sles15-zen2
+berkeley-db,18.1.40,cce@12.0.1,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,cray-sles15-zen2
+berkeley-db,18.1.40,gcc@7.5.0,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,linux-sles15-x86_64
+berkeley-db,18.1.40,gcc@10.2.0,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,cray-sles15-zen2
+berkeley-db,18.1.40,gcc@10.3.0,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,cray-sles15-zen2
+binutils,2.36.1,gcc@10.2.0,~gas~gold~headers~interwork~ld+libiberty~lto+nls+plugins libs=shared,static,cray-sles15-zen2
+binutils,2.36.1,gcc@10.3.0,~gas~gold~headers~interwork~ld+libiberty~lto+nls+plugins libs=shared,static,cray-sles15-zen2
+binutils,2.36.1,gcc@7.5.0,~gas+gold~headers~interwork+ld+libiberty~lto+nls+plugins libs=shared,static,linux-sles15-x86_64
+bison,3.7.6,cce@12.0.0,,cray-sles15-zen2
+bison,3.7.6,cce@12.0.1,,cray-sles15-zen2
+bison,3.7.6,gcc@7.5.0,,linux-sles15-x86_64
+bison,3.7.6,gcc@10.2.0,,cray-sles15-zen2
+bison,3.7.6,gcc@10.3.0,,cray-sles15-zen2
+blaspp,2021.04.01,gcc@10.2.0,~cuda~ipo+openmp+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+blaspp,2021.04.01,gcc@10.3.0,~cuda~ipo+openmp+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+blt,0.3.6,cce@12.0.0,,cray-sles15-zen2
+blt,0.3.6,cce@12.0.1,,cray-sles15-zen2
+blt,0.3.6,gcc@10.2.0,,cray-sles15-zen2
+blt,0.3.6,gcc@10.3.0,,cray-sles15-zen2
+bolt,2.0,cce@12.0.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+bolt,2.0,cce@12.0.1,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+bolt,2.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+bolt,2.0,gcc@10.3.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+boost,1.76.0,cce@12.0.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=17 patches=57a8401dee8f52b0342e0c8147a5b2db834e8d8f3fbcbbc5950016bd3e9e1ef0 visibility=hidden,cray-sles15-zen2
+boost,1.76.0,cce@12.0.1,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=17 patches=57a8401dee8f52b0342e0c8147a5b2db834e8d8f3fbcbbc5950016bd3e9e1ef0 visibility=hidden,cray-sles15-zen2
+boost,1.76.0,gcc@10.2.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=17 patches=57a8401dee8f52b0342e0c8147a5b2db834e8d8f3fbcbbc5950016bd3e9e1ef0 visibility=hidden,cray-sles15-zen2
+boost,1.76.0,gcc@10.3.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=17 patches=57a8401dee8f52b0342e0c8147a5b2db834e8d8f3fbcbbc5950016bd3e9e1ef0 visibility=hidden,cray-sles15-zen2
+boost,1.76.0,gcc@10.2.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=57a8401dee8f52b0342e0c8147a5b2db834e8d8f3fbcbbc5950016bd3e9e1ef0 visibility=global,cray-sles15-zen2
+boost,1.76.0,gcc@10.3.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=57a8401dee8f52b0342e0c8147a5b2db834e8d8f3fbcbbc5950016bd3e9e1ef0 visibility=global,cray-sles15-zen2
+boost,1.76.0,cce@12.0.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=57a8401dee8f52b0342e0c8147a5b2db834e8d8f3fbcbbc5950016bd3e9e1ef0 visibility=hidden,cray-sles15-zen2
+boost,1.76.0,cce@12.0.1,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=57a8401dee8f52b0342e0c8147a5b2db834e8d8f3fbcbbc5950016bd3e9e1ef0 visibility=hidden,cray-sles15-zen2
+boost,1.76.0,gcc@10.2.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=57a8401dee8f52b0342e0c8147a5b2db834e8d8f3fbcbbc5950016bd3e9e1ef0 visibility=hidden,cray-sles15-zen2
+boost,1.76.0,gcc@10.3.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=57a8401dee8f52b0342e0c8147a5b2db834e8d8f3fbcbbc5950016bd3e9e1ef0 visibility=hidden,cray-sles15-zen2
+bzip2,1.0.8,cce@12.0.0,~debug~pic+shared,cray-sles15-zen2
+bzip2,1.0.8,cce@12.0.1,~debug~pic+shared,cray-sles15-zen2
+bzip2,1.0.8,gcc@7.5.0,~debug~pic+shared,linux-sles15-x86_64
+bzip2,1.0.8,gcc@10.2.0,~debug~pic+shared,cray-sles15-zen2
+bzip2,1.0.8,gcc@10.3.0,~debug~pic+shared,cray-sles15-zen2
+c-blosc,1.21.0,cce@12.0.0,+avx2~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+c-blosc,1.21.0,cce@12.0.1,+avx2~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+c-blosc,1.21.0,gcc@10.2.0,+avx2~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+c-blosc,1.21.0,gcc@10.3.0,+avx2~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+cabana,0.3.0,cce@12.0.0,~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo,cray-sles15-zen2
+cabana,0.3.0,cce@12.0.1,~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo,cray-sles15-zen2
+cabana,0.3.0,gcc@10.2.0,~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo,cray-sles15-zen2
+cabana,0.3.0,gcc@10.3.0,~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo,cray-sles15-zen2
+cairo,1.16.0,gcc@7.5.0,~X+fc+ft+gobject+pdf~png~svg patches=7c4da77767fe9feb03f8051def0832f0c67f99162913275cfa127a88df19cf51,linux-sles15-x86_64
+cairo,1.16.0,gcc@7.5.0,+X+fc+ft+gobject+pdf~png~svg patches=7c4da77767fe9feb03f8051def0832f0c67f99162913275cfa127a88df19cf51,linux-sles15-x86_64
+caliper,2.5.0,gcc@10.2.0,+adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+caliper,2.5.0,gcc@10.3.0,+adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+camp,0.1.0,cce@12.0.0,~cuda~ipo~rocm~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+camp,0.1.0,cce@12.0.1,~cuda~ipo~rocm~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+camp,0.1.0,gcc@10.2.0,~cuda~ipo~rocm~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+camp,0.1.0,gcc@10.3.0,~cuda~ipo~rocm~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+ccache,4.3,gcc@7.5.0,~ipo build_type=RelWithDebInfo,linux-sles15-x86_64
+chai,2.3.0,cce@12.0.0,~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+chai,2.3.0,cce@12.0.1,~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+chai,2.3.0,gcc@10.2.0,~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+chai,2.3.0,gcc@10.3.0,~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+cinch,master,cce@12.0.0,,cray-sles15-zen2
+cinch,master,cce@12.0.1,,cray-sles15-zen2
+cinch,master,gcc@10.2.0,,cray-sles15-zen2
+cinch,master,gcc@10.3.0,,cray-sles15-zen2
+cmake,3.20.2,cce@12.0.0,~doc+ncurses+openssl+ownlibs~qt build_type=Release,cray-sles15-zen2
+cmake,3.20.2,cce@12.0.1,~doc+ncurses+openssl+ownlibs~qt build_type=Release,cray-sles15-zen2
+cmake,3.20.2,gcc@7.5.0,~doc+ncurses+openssl+ownlibs~qt build_type=Release,linux-sles15-x86_64
+cmake,3.20.2,gcc@10.2.0,~doc+ncurses+openssl+ownlibs~qt build_type=Release,cray-sles15-zen2
+cmake,3.20.2,gcc@10.3.0,~doc+ncurses+openssl+ownlibs~qt build_type=Release,cray-sles15-zen2
+cmake,3.21.2-dev,gcc@7.5.0,~doc+ncurses+openssl+ownlibs~qt build_type=Release,linux-sles15-x86_64
+conduit,0.7.2,cce@12.0.0,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,cray-sles15-zen2
+conduit,0.7.2,cce@12.0.1,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,cray-sles15-zen2
+conduit,0.7.2,gcc@10.2.0,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,cray-sles15-zen2
+conduit,0.7.2,gcc@10.3.0,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,cray-sles15-zen2
+cray-libsci,21.06.1.1,cce@12.0.0,~mpi~openmp+shared,cray-sles15-zen2
+cray-libsci,21.06.1.1,cce@12.0.1,~mpi~openmp+shared,cray-sles15-zen2
+cray-libsci,21.06.1.1,gcc@10.2.0,~mpi~openmp+shared,cray-sles15-zen2
+cray-libsci,21.06.1.1,gcc@10.3.0,~mpi~openmp+shared,cray-sles15-zen2
+cray-mpich,8.1.7,cce@12.0.0,,cray-sles15-zen2
+cray-mpich,8.1.7,cce@12.0.1,,cray-sles15-zen2
+cray-mpich,8.1.7,gcc@10.2.0,,cray-sles15-zen2
+cray-mpich,8.1.7,gcc@10.3.0,,cray-sles15-zen2
+curl,7.76.1,cce@12.0.0,~darwinssl~gssapi~libssh~libssh2~nghttp2,cray-sles15-zen2
+curl,7.76.1,cce@12.0.1,~darwinssl~gssapi~libssh~libssh2~nghttp2,cray-sles15-zen2
+curl,7.76.1,gcc@7.5.0,~darwinssl~gssapi~libssh~libssh2~nghttp2,linux-sles15-x86_64
+curl,7.76.1,gcc@10.2.0,~darwinssl~gssapi~libssh~libssh2~nghttp2,cray-sles15-zen2
+curl,7.76.1,gcc@10.3.0,~darwinssl~gssapi~libssh~libssh2~nghttp2,cray-sles15-zen2
+darshan-util,3.3.0,cce@12.0.0,~apmpi~apxc~bzip2+shared,cray-sles15-zen2
+darshan-util,3.3.0,cce@12.0.1,~apmpi~apxc~bzip2+shared,cray-sles15-zen2
+darshan-util,3.3.0,gcc@7.5.0,~apmpi~apxc~bzip2+shared,linux-sles15-x86_64
+darshan-util,3.3.0,gcc@10.2.0,~apmpi~apxc~bzip2+shared,cray-sles15-zen2
+darshan-util,3.3.0,gcc@10.3.0,~apmpi~apxc~bzip2+shared,cray-sles15-zen2
+dbus,1.12.8,gcc@7.5.0,,linux-sles15-x86_64
+diffutils,3.7,cce@12.0.0,,cray-sles15-zen2
+diffutils,3.7,cce@12.0.1,,cray-sles15-zen2
+diffutils,3.7,gcc@7.5.0,,linux-sles15-x86_64
+diffutils,3.7,gcc@10.2.0,,cray-sles15-zen2
+diffutils,3.7,gcc@10.3.0,,cray-sles15-zen2
+docbook-xml,4.3,gcc@7.5.0,,linux-sles15-x86_64
+docbook-xsl,1.78.1,gcc@7.5.0,,linux-sles15-x86_64
+dyninst,11.0.0,gcc@10.2.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,cray-sles15-zen2
+dyninst,11.0.0,gcc@10.2.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,cray-sles15-zen2
+dyninst,11.0.0,gcc@10.3.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,cray-sles15-zen2
+dyninst,11.0.0,gcc@10.3.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,cray-sles15-zen2
+eigen,3.3.9,gcc@10.2.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+eigen,3.3.9,gcc@10.3.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+elfutils,0.182,gcc@10.2.0,~bzip2~debuginfod+nls~xz,cray-sles15-zen2
+elfutils,0.182,gcc@10.3.0,~bzip2~debuginfod+nls~xz,cray-sles15-zen2
+elfutils,0.182,gcc@10.2.0,+bzip2~debuginfod~nls+xz,cray-sles15-zen2
+elfutils,0.182,gcc@10.3.0,+bzip2~debuginfod~nls+xz,cray-sles15-zen2
+emacs,27.2,gcc@7.5.0,+X~native~tls toolkit=gtk,linux-sles15-x86_64
+exmcutils,0.6.0,cce@12.0.0,,cray-sles15-zen2
+exmcutils,0.6.0,cce@12.0.1,,cray-sles15-zen2
+exmcutils,0.6.0,gcc@10.2.0,,cray-sles15-zen2
+exmcutils,0.6.0,gcc@10.3.0,,cray-sles15-zen2
+expat,2.3.0,cce@12.0.0,+libbsd,cray-sles15-zen2
+expat,2.3.0,cce@12.0.1,+libbsd,cray-sles15-zen2
+expat,2.3.0,gcc@7.5.0,+libbsd,linux-sles15-x86_64
+expat,2.3.0,gcc@10.2.0,+libbsd,cray-sles15-zen2
+expat,2.3.0,gcc@10.3.0,+libbsd,cray-sles15-zen2
+faodel,1.1906.1,cce@12.0.0,~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68,cray-sles15-zen2
+faodel,1.1906.1,cce@12.0.1,~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68,cray-sles15-zen2
+faodel,1.1906.1,gcc@10.2.0,~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68,cray-sles15-zen2
+faodel,1.1906.1,gcc@10.3.0,~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68,cray-sles15-zen2
+fftw,3.3.9,cce@12.0.0,+mpi~openmp~pfft_patches precision=double,float,long_double,cray-sles15-zen2
+fftw,3.3.9,cce@12.0.1,+mpi~openmp~pfft_patches precision=double,float,long_double,cray-sles15-zen2
+fftw,3.3.9,gcc@10.2.0,+mpi~openmp~pfft_patches precision=double,float,long_double,cray-sles15-zen2
+fftw,3.3.9,gcc@10.3.0,+mpi~openmp~pfft_patches precision=double,float,long_double,cray-sles15-zen2
+findutils,4.8.0,gcc@7.5.0,,linux-sles15-x86_64
+fixesproto,5.0,gcc@7.5.0,,linux-sles15-x86_64
+flecsi,1.4,cce@12.0.0,~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release,cray-sles15-zen2
+flecsi,1.4,cce@12.0.1,~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release,cray-sles15-zen2
+flecsi,1.4,gcc@10.2.0,~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release,cray-sles15-zen2
+flecsi,1.4,gcc@10.3.0,~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release,cray-sles15-zen2
+flex,2.6.3,gcc@7.5.0,+lex~nls,linux-sles15-x86_64
+flit,2.1.0,cce@12.0.0,,cray-sles15-zen2
+flit,2.1.0,cce@12.0.1,,cray-sles15-zen2
+flit,2.1.0,gcc@10.2.0,,cray-sles15-zen2
+flit,2.1.0,gcc@10.3.0,,cray-sles15-zen2
+font-util,1.3.2,gcc@7.5.0, fonts=encodings,font-adobe-100dpi,font-adobe-75dpi,font-adobe-utopia-100dpi,font-adobe-utopia-75dpi,font-adobe-utopia-type1,font-alias,font-arabic-misc,font-bh-100dpi,font-bh-75dpi,font-bh-lucidatypewriter-100dpi,font-bh-lucidatypewriter-75dpi,font-bh-type1,font-bitstream-100dpi,font-bitstream-75dpi,font-bitstream-speedo,font-bitstream-type1,font-cronyx-cyrillic,font-cursor-misc,font-daewoo-misc,font-dec-misc,font-ibm-type1,font-isas-misc,font-jis-misc,font-micro-misc,font-misc-cyrillic,font-misc-ethiopic,font-misc-meltho,font-misc-misc,font-mutt-misc,font-schumacher-misc,font-screen-cyrillic,font-sun-misc,font-winitzki-cyrillic,font-xfree86-type1,linux-sles15-x86_64
+fontconfig,2.13.93,gcc@7.5.0,,linux-sles15-x86_64
+fontsproto,2.1.3,gcc@7.5.0,,linux-sles15-x86_64
+freetype,2.10.4,gcc@7.5.0,,linux-sles15-x86_64
+fribidi,1.0.5,gcc@7.5.0,,linux-sles15-x86_64
+gasnet,2020.3.0,cce@12.0.0,~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB,cray-sles15-zen2
+gasnet,2020.3.0,cce@12.0.1,~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB,cray-sles15-zen2
+gasnet,2020.3.0,gcc@10.2.0,~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB,cray-sles15-zen2
+gasnet,2020.3.0,gcc@10.3.0,~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB,cray-sles15-zen2
+gawk,5.1.0,gcc@7.5.0,,linux-sles15-x86_64
+gdb,10.2,gcc@7.5.0,~gold~ld~lto+python~quad~source-highlight~tui+xz patches=0b73f4c573768130ab59fa218cfc352d1db9678423ce787012e46e589154745c,linux-sles15-x86_64
+gdbm,1.19,cce@12.0.0,,cray-sles15-zen2
+gdbm,1.19,cce@12.0.1,,cray-sles15-zen2
+gdbm,1.19,gcc@7.5.0,,linux-sles15-x86_64
+gdbm,1.19,gcc@10.2.0,,cray-sles15-zen2
+gdbm,1.19,gcc@10.3.0,,cray-sles15-zen2
+gdk-pixbuf,2.42.2,gcc@7.5.0,~man~x11,linux-sles15-x86_64
+gettext,0.21,cce@12.0.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,cray-sles15-zen2
+gettext,0.21,cce@12.0.1,+bzip2+curses+git~libunistring+libxml2+tar+xz,cray-sles15-zen2
+gettext,0.21,gcc@7.5.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-sles15-x86_64
+gettext,0.21,gcc@10.2.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,cray-sles15-zen2
+gettext,0.21,gcc@10.2.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,cray-sles15-zen2
+gettext,0.21,gcc@10.3.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,cray-sles15-zen2
+gettext,0.21,gcc@10.3.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,cray-sles15-zen2
+ghostscript,9.54.0,gcc@7.5.0,,linux-sles15-x86_64
+ghostscript-fonts,8.11,gcc@7.5.0,,linux-sles15-x86_64
+giflib,5.1.4,gcc@7.5.0, patches=5cc0447986963199fa6f382ce7ef55dd033344a92d2145277d3c1def8190d258,linux-sles15-x86_64
+git,2.31.1,cce@12.0.0,+man+nls+perl~svn~tcltk,cray-sles15-zen2
+git,2.31.1,cce@12.0.1,+man+nls+perl~svn~tcltk,cray-sles15-zen2
+git,2.31.1,gcc@7.5.0,+man+nls+perl~svn~tcltk,linux-sles15-x86_64
+git,2.31.1,gcc@10.2.0,+man+nls+perl~svn~tcltk,cray-sles15-zen2
+git,2.31.1,gcc@10.3.0,+man+nls+perl~svn~tcltk,cray-sles15-zen2
+glib,2.68.2,gcc@7.5.0,~libmount patches=b3fd45063a19c871048aa1f28692293ab8971a871bdcbe65f06f17fdd79db9e2 tracing=none,linux-sles15-x86_64
+glm,0.9.9.8,cce@12.0.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+glm,0.9.9.8,cce@12.0.1,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+glm,0.9.9.8,gcc@10.2.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+glm,0.9.9.8,gcc@10.3.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+globalarrays,5.8,cce@12.0.0,~scalapack armci=mpi-ts,cray-sles15-zen2
+globalarrays,5.8,cce@12.0.1,~scalapack armci=mpi-ts,cray-sles15-zen2
+globalarrays,5.8,gcc@10.2.0,~scalapack armci=mpi-ts,cray-sles15-zen2
+globalarrays,5.8,gcc@10.3.0,~scalapack armci=mpi-ts,cray-sles15-zen2
+glproto,1.4.17,gcc@7.5.0,,linux-sles15-x86_64
+gmake,4.3,cce@12.0.0,~guile+nls,cray-sles15-zen2
+gmake,4.3,cce@12.0.1,~guile+nls,cray-sles15-zen2
+gmake,4.3,gcc@7.5.0,~guile+nls,linux-sles15-x86_64
+gmake,4.3,gcc@10.2.0,~guile+nls,cray-sles15-zen2
+gmake,4.3,gcc@10.3.0,~guile+nls,cray-sles15-zen2
+gmp,6.2.1,cce@12.0.0,,cray-sles15-zen2
+gmp,6.2.1,cce@12.0.1,,cray-sles15-zen2
+gmp,6.2.1,gcc@7.5.0,,linux-sles15-x86_64
+gmp,6.2.1,gcc@10.2.0,,cray-sles15-zen2
+gmp,6.2.1,gcc@10.3.0,,cray-sles15-zen2
+gnupg,2.2.19,gcc@7.5.0,,linux-sles15-x86_64
+gnuplot,5.2.8,gcc@7.5.0,+X+cairo+gd+libcerf~pbm~qt~wx patches=ad89f23815fd925889ae78009ba22e6f9e4b12fea389280040cef519deafb052,linux-sles15-x86_64
+go,1.16.4,gcc@7.5.0,,linux-sles15-x86_64
+go-bootstrap,1.4-bootstrap-20171003,gcc@7.5.0,,linux-sles15-x86_64
+gobject-introspection,1.56.1,gcc@7.5.0, patches=6f90bb267efa043ed70b900b4b8e2faf9e8133afae311893b01060356ea81bba,7700828b638c85255c87fcc317ea7e9572ff443f65c86648796528885e5b4cea,linux-sles15-x86_64
+gobject-introspection,1.56.1,gcc@7.5.0, patches=6f90bb267efa043ed70b900b4b8e2faf9e8133afae311893b01060356ea81bba,7700828b638c85255c87fcc317ea7e9572ff443f65c86648796528885e5b4cea,linux-sles15-x86_64
+googletest,1.8.1,cce@12.0.0,+gmock~ipo+pthreads+shared build_type=RelWithDebInfo,cray-sles15-zen2
+googletest,1.8.1,cce@12.0.1,+gmock~ipo+pthreads+shared build_type=RelWithDebInfo,cray-sles15-zen2
+googletest,1.8.1,gcc@10.2.0,+gmock~ipo+pthreads+shared build_type=RelWithDebInfo,cray-sles15-zen2
+googletest,1.8.1,gcc@10.3.0,+gmock~ipo+pthreads+shared build_type=RelWithDebInfo,cray-sles15-zen2
+googletest,1.11.0,gcc@7.5.0,~gmock~ipo+pthreads+shared build_type=RelWithDebInfo,linux-sles15-x86_64
+gotcha,1.0.3,cce@12.0.0,~ipo~test build_type=RelWithDebInfo,cray-sles15-zen2
+gotcha,1.0.3,cce@12.0.1,~ipo~test build_type=RelWithDebInfo,cray-sles15-zen2
+gotcha,1.0.3,gcc@10.2.0,~ipo~test build_type=RelWithDebInfo,cray-sles15-zen2
+gotcha,1.0.3,gcc@10.3.0,~ipo~test build_type=RelWithDebInfo,cray-sles15-zen2
+gperf,3.1,gcc@7.5.0,,linux-sles15-x86_64
+gperftools,2.8.1,cce@12.0.0,,cray-sles15-zen2
+gperftools,2.8.1,cce@12.0.1,,cray-sles15-zen2
+gperftools,2.8.1,gcc@10.2.0,,cray-sles15-zen2
+gperftools,2.8.1,gcc@10.3.0,,cray-sles15-zen2
+gtk-doc,1.32,gcc@7.5.0, patches=2ba1c038e5bbc82b679684bdcfaf4309c262ebd76ab7b1d8f57c954d6913badb,linux-sles15-x86_64
+gtkplus,3.24.26,gcc@7.5.0,~cups~strip buildtype=debugoptimized default_library=shared,linux-sles15-x86_64
+harfbuzz,2.6.8,gcc@7.5.0,~graphite2,linux-sles15-x86_64
+harfbuzz,2.6.8,gcc@7.5.0,~graphite2,linux-sles15-x86_64
+hdf5,1.8.22,cce@12.0.0,~cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,cray-sles15-zen2
+hdf5,1.8.22,cce@12.0.1,~cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,cray-sles15-zen2
+hdf5,1.8.22,gcc@10.2.0,~cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,cray-sles15-zen2
+hdf5,1.8.22,gcc@10.3.0,~cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,cray-sles15-zen2
+hdf5,1.10.7,cce@12.0.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,cray-sles15-zen2
+hdf5,1.10.7,cce@12.0.1,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,cray-sles15-zen2
+hdf5,1.10.7,gcc@10.2.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,cray-sles15-zen2
+hdf5,1.10.7,gcc@10.3.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,cray-sles15-zen2
+heffte,2.0.0,cce@12.0.0,~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c,cray-sles15-zen2
+heffte,2.0.0,cce@12.0.1,~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c,cray-sles15-zen2
+heffte,2.0.0,gcc@10.2.0,~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c,cray-sles15-zen2
+heffte,2.0.0,gcc@10.3.0,~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c,cray-sles15-zen2
+hip,4.2.0,cce@12.0.0,~ipo build_type=RelWithDebInfo patches=2a4190477b7d9206b9cd8d70770ba0bc007273cbe54772efb12f9ca2e37c0392,e276c4acf3d37712b6bea306fea34f539d3c4f743471e9da208b5eb17b16ae67,cray-sles15-zen2
+hip,4.2.0,cce@12.0.1,~ipo build_type=RelWithDebInfo patches=2a4190477b7d9206b9cd8d70770ba0bc007273cbe54772efb12f9ca2e37c0392,e276c4acf3d37712b6bea306fea34f539d3c4f743471e9da208b5eb17b16ae67,cray-sles15-zen2
+hip,4.3.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo patches=2a4190477b7d9206b9cd8d70770ba0bc007273cbe54772efb12f9ca2e37c0392,cray-sles15-zen2
+hip,4.3.0,gcc@10.3.0,~ipo build_type=RelWithDebInfo patches=2a4190477b7d9206b9cd8d70770ba0bc007273cbe54772efb12f9ca2e37c0392,cray-sles15-zen2
+hipblas,4.2.0,cce@12.0.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+hipblas,4.2.0,cce@12.0.1,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+hipblas,4.3.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+hipblas,4.3.0,gcc@10.3.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+hipsparse,4.2.0,cce@12.0.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+hipsparse,4.2.0,cce@12.0.1,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+hipsparse,4.3.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+hipsparse,4.3.0,gcc@10.3.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+hpctoolkit,2021.03.01,gcc@10.2.0,~all-static~cray~cuda~mpi+papi~rocm,cray-sles15-zen2
+hpctoolkit,2021.03.01,gcc@10.3.0,~all-static~cray~cuda~mpi+papi~rocm,cray-sles15-zen2
+hpx,1.6.0,cce@12.0.0,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,cray-sles15-zen2
+hpx,1.6.0,cce@12.0.1,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,cray-sles15-zen2
+hpx,1.6.0,gcc@10.2.0,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,cray-sles15-zen2
+hpx,1.6.0,gcc@10.3.0,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,cray-sles15-zen2
+hsa-rocr-dev,4.2.0,cce@12.0.0,+image~ipo+shared build_type=Release patches=71e6851d9be8113bfb8d71b66a3171e0d0401bae5e6f161c9e7fe32558261a46,cray-sles15-zen2
+hsa-rocr-dev,4.2.0,cce@12.0.1,+image~ipo+shared build_type=Release patches=71e6851d9be8113bfb8d71b66a3171e0d0401bae5e6f161c9e7fe32558261a46,cray-sles15-zen2
+hsa-rocr-dev,4.3.0,gcc@10.2.0,+image~ipo+shared build_type=Release patches=71e6851d9be8113bfb8d71b66a3171e0d0401bae5e6f161c9e7fe32558261a46,cray-sles15-zen2
+hsa-rocr-dev,4.3.0,gcc@10.3.0,+image~ipo+shared build_type=Release patches=71e6851d9be8113bfb8d71b66a3171e0d0401bae5e6f161c9e7fe32558261a46,cray-sles15-zen2
+htop,3.0.2,gcc@7.5.0,+unicode,linux-sles15-x86_64
+hwloc,2.4.1,cce@12.0.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared,cray-sles15-zen2
+hwloc,2.4.1,cce@12.0.1,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared,cray-sles15-zen2
+hwloc,2.4.1,gcc@7.5.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared,linux-sles15-x86_64
+hwloc,2.4.1,gcc@10.2.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared,cray-sles15-zen2
+hwloc,2.4.1,gcc@10.3.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared,cray-sles15-zen2
+hypre,2.20.0,cce@12.0.0,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,cray-sles15-zen2
+hypre,2.20.0,cce@12.0.1,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,cray-sles15-zen2
+hypre,2.20.0,gcc@10.2.0,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,cray-sles15-zen2
+hypre,2.20.0,gcc@10.3.0,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,cray-sles15-zen2
+icu4c,67.1,gcc@7.5.0, cxxstd=11,linux-sles15-x86_64
+imagemagick,7.0.8-7,gcc@7.5.0,,linux-sles15-x86_64
+inputproto,2.3.2,gcc@7.5.0,,linux-sles15-x86_64
+intel-tbb,2020.3,gcc@10.2.0,+shared+tm cxxstd=default patches=62ba015ebd1819c45bef47411540b789b493e31ca668c4ff4cb2afcbc306b476,ce1fb16fb932ce86a82ca87cf0431d1a8c83652af9f552b264213b2ff2945d73,d62cb666de4010998c339cde6f41c7623a07e9fc69e498f2e149821c0c2c6dd0,cray-sles15-zen2
+intel-tbb,2020.3,gcc@10.3.0,+shared+tm cxxstd=default patches=62ba015ebd1819c45bef47411540b789b493e31ca668c4ff4cb2afcbc306b476,ce1fb16fb932ce86a82ca87cf0431d1a8c83652af9f552b264213b2ff2945d73,d62cb666de4010998c339cde6f41c7623a07e9fc69e498f2e149821c0c2c6dd0,cray-sles15-zen2
+intel-xed,12.0.1,gcc@10.2.0,~debug~pic patches=acffa07ee4b8e898df18f1439547e45ec9c609328dfb6e1ad2dce416587334d4,cray-sles15-zen2
+intel-xed,12.0.1,gcc@10.3.0,~debug~pic patches=acffa07ee4b8e898df18f1439547e45ec9c609328dfb6e1ad2dce416587334d4,cray-sles15-zen2
+intltool,0.51.0,gcc@7.5.0, patches=ca9d6562f29f06c64150f50369a24402b7aa01a3a0dc73dce55106f3224330a1,linux-sles15-x86_64
+kbproto,1.0.7,gcc@7.5.0,,linux-sles15-x86_64
+kokkos,3.4.00,cce@12.0.0,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,cce@12.0.1,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,gcc@10.2.0,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,gcc@10.3.0,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,cce@12.0.0,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,cce@12.0.1,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,gcc@10.2.0,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,gcc@10.3.0,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,cce@12.0.0,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,cce@12.0.1,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,gcc@10.2.0,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos,3.4.00,gcc@10.3.0,~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14,cray-sles15-zen2
+kokkos-kernels,3.2.00,cce@12.0.0,~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double,cray-sles15-zen2
+kokkos-kernels,3.2.00,cce@12.0.1,~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double,cray-sles15-zen2
+kokkos-kernels,3.2.00,gcc@10.2.0,~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double,cray-sles15-zen2
+kokkos-kernels,3.2.00,gcc@10.3.0,~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double,cray-sles15-zen2
+krb5,1.18.2,gcc@7.5.0,+shared patches=3d75052730690579484e65a5bf0f92f6c3b20d9c43a413862d087774f431d9e9,linux-sles15-x86_64
+lapackpp,2021.04.00,gcc@10.2.0,~ipo+shared build_type=RelWithDebInfo,cray-sles15-zen2
+lapackpp,2021.04.00,gcc@10.3.0,~ipo+shared build_type=RelWithDebInfo,cray-sles15-zen2
+lcms,2.9,gcc@7.5.0,,linux-sles15-x86_64
+legion,21.03.0,cce@12.0.0,~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,cray-sles15-zen2
+legion,21.03.0,cce@12.0.1,~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,cray-sles15-zen2
+legion,21.03.0,gcc@10.2.0,~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,cray-sles15-zen2
+legion,21.03.0,gcc@10.3.0,~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,cray-sles15-zen2
+libassuan,2.5.5,gcc@7.5.0,,linux-sles15-x86_64
+libbsd,0.11.3,cce@12.0.0,,cray-sles15-zen2
+libbsd,0.11.3,cce@12.0.1,,cray-sles15-zen2
+libbsd,0.11.3,gcc@7.5.0,,linux-sles15-x86_64
+libbsd,0.11.3,gcc@10.2.0,,cray-sles15-zen2
+libbsd,0.11.3,gcc@10.3.0,,cray-sles15-zen2
+libcerf,1.3,gcc@7.5.0,,linux-sles15-x86_64
+libcroco,0.6.13,gcc@7.5.0,,linux-sles15-x86_64
+libdwarf,20180129,gcc@10.2.0,,cray-sles15-zen2
+libdwarf,20180129,gcc@10.3.0,,cray-sles15-zen2
+libedit,3.1-20210216,cce@12.0.0,,cray-sles15-zen2
+libedit,3.1-20210216,cce@12.0.1,,cray-sles15-zen2
+libedit,3.1-20210216,gcc@7.5.0,,linux-sles15-x86_64
+libedit,3.1-20210216,gcc@10.2.0,,cray-sles15-zen2
+libedit,3.1-20210216,gcc@10.3.0,,cray-sles15-zen2
+libepoxy,1.4.3,gcc@7.5.0,+glx,linux-sles15-x86_64
+libevent,2.1.12,gcc@7.5.0,+openssl,linux-sles15-x86_64
+libfabric,1.11.0.4.75,cce@12.0.0,~kdreg fabrics=sockets,tcp,udp,cray-sles15-zen2
+libfabric,1.11.0.4.75,cce@12.0.1,~kdreg fabrics=sockets,tcp,udp,cray-sles15-zen2
+libfabric,1.11.0.4.75,gcc@10.2.0,~kdreg fabrics=sockets,tcp,udp,cray-sles15-zen2
+libfabric,1.11.0.4.75,gcc@10.3.0,~kdreg fabrics=sockets,tcp,udp,cray-sles15-zen2
+libffi,3.3,cce@12.0.0, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,cray-sles15-zen2
+libffi,3.3,cce@12.0.1, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,cray-sles15-zen2
+libffi,3.3,gcc@7.5.0, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,linux-sles15-x86_64
+libffi,3.3,gcc@10.2.0, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,cray-sles15-zen2
+libffi,3.3,gcc@10.3.0, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,cray-sles15-zen2
+libfontenc,1.1.3,gcc@7.5.0,,linux-sles15-x86_64
+libgcrypt,1.9.3,gcc@7.5.0,,linux-sles15-x86_64
+libgd,2.2.4,gcc@7.5.0,,linux-sles15-x86_64
+libgit2,1.1.0,gcc@7.5.0,~curl~ipo+ssh build_type=RelWithDebInfo https=system,linux-sles15-x86_64
+libgpg-error,1.42,gcc@7.5.0,,linux-sles15-x86_64
+libiberty,2.33.1,gcc@10.2.0,+pic,cray-sles15-zen2
+libiberty,2.33.1,gcc@10.3.0,+pic,cray-sles15-zen2
+libice,1.0.9,gcc@7.5.0,,linux-sles15-x86_64
+libiconv,1.16,cce@12.0.0,,cray-sles15-zen2
+libiconv,1.16,cce@12.0.1,,cray-sles15-zen2
+libiconv,1.16,gcc@7.5.0,,linux-sles15-x86_64
+libiconv,1.16,gcc@10.2.0,,cray-sles15-zen2
+libiconv,1.16,gcc@10.3.0,,cray-sles15-zen2
+libidn2,2.3.0,cce@12.0.0,,cray-sles15-zen2
+libidn2,2.3.0,cce@12.0.1,,cray-sles15-zen2
+libidn2,2.3.0,gcc@7.5.0,,linux-sles15-x86_64
+libidn2,2.3.0,gcc@10.2.0,,cray-sles15-zen2
+libidn2,2.3.0,gcc@10.3.0,,cray-sles15-zen2
+libjpeg-turbo,2.0.6,gcc@7.5.0,,linux-sles15-x86_64
+libksba,1.5.1,gcc@7.5.0,,linux-sles15-x86_64
+libmd,1.0.3,cce@12.0.0,,cray-sles15-zen2
+libmd,1.0.3,cce@12.0.1,,cray-sles15-zen2
+libmd,1.0.3,gcc@7.5.0,,linux-sles15-x86_64
+libmd,1.0.3,gcc@10.2.0,,cray-sles15-zen2
+libmd,1.0.3,gcc@10.3.0,,cray-sles15-zen2
+libmonitor,2021.04.27,gcc@10.2.0,~commrank~dlopen+hpctoolkit,cray-sles15-zen2
+libmonitor,2021.04.27,gcc@10.3.0,~commrank~dlopen+hpctoolkit,cray-sles15-zen2
+libpciaccess,0.16,cce@12.0.0,,cray-sles15-zen2
+libpciaccess,0.16,cce@12.0.1,,cray-sles15-zen2
+libpciaccess,0.16,gcc@7.5.0,,linux-sles15-x86_64
+libpciaccess,0.16,gcc@10.2.0,,cray-sles15-zen2
+libpciaccess,0.16,gcc@10.3.0,,cray-sles15-zen2
+libpng,1.2.57,gcc@7.5.0,,linux-sles15-x86_64
+libpng,1.6.37,cce@12.0.0,,cray-sles15-zen2
+libpng,1.6.37,cce@12.0.1,,cray-sles15-zen2
+libpng,1.6.37,gcc@7.5.0,,linux-sles15-x86_64
+libpng,1.6.37,gcc@10.2.0,,cray-sles15-zen2
+libpng,1.6.37,gcc@10.3.0,,cray-sles15-zen2
+libpthread-stubs,0.4,gcc@7.5.0,,linux-sles15-x86_64
+libquo,1.3.1,cce@12.0.0,,cray-sles15-zen2
+libquo,1.3.1,cce@12.0.1,,cray-sles15-zen2
+libquo,1.3.1,gcc@10.2.0,,cray-sles15-zen2
+libquo,1.3.1,gcc@10.3.0,,cray-sles15-zen2
+librsvg,2.51.0,gcc@7.5.0,,linux-sles15-x86_64
+libsigsegv,2.13,cce@12.0.0,,cray-sles15-zen2
+libsigsegv,2.13,cce@12.0.1,,cray-sles15-zen2
+libsigsegv,2.13,gcc@7.5.0,,linux-sles15-x86_64
+libsigsegv,2.13,gcc@10.2.0,,cray-sles15-zen2
+libsigsegv,2.13,gcc@10.3.0,,cray-sles15-zen2
+libsm,1.2.3,gcc@7.5.0,,linux-sles15-x86_64
+libsodium,1.0.18,gcc@7.5.0,,linux-sles15-x86_64
+libssh2,1.8.0,gcc@7.5.0,~ipo+shared build_type=RelWithDebInfo,linux-sles15-x86_64
+libtiff,4.1.0,gcc@7.5.0,,linux-sles15-x86_64
+libtool,2.4.6,cce@12.0.0,,cray-sles15-zen2
+libtool,2.4.6,cce@12.0.1,,cray-sles15-zen2
+libtool,2.4.6,gcc@7.5.0,,linux-sles15-x86_64
+libtool,2.4.6,gcc@10.2.0,,cray-sles15-zen2
+libtool,2.4.6,gcc@10.3.0,,cray-sles15-zen2
+libunistring,0.9.10,cce@12.0.0,,cray-sles15-zen2
+libunistring,0.9.10,cce@12.0.1,,cray-sles15-zen2
+libunistring,0.9.10,gcc@7.5.0,,linux-sles15-x86_64
+libunistring,0.9.10,gcc@10.2.0,,cray-sles15-zen2
+libunistring,0.9.10,gcc@10.3.0,,cray-sles15-zen2
+libunwind,1.5.0,cce@12.0.0,~pic~xz~zlib,cray-sles15-zen2
+libunwind,1.5.0,cce@12.0.1,~pic~xz~zlib,cray-sles15-zen2
+libunwind,1.5.0,gcc@10.2.0,~pic~xz~zlib,cray-sles15-zen2
+libunwind,1.5.0,gcc@10.3.0,~pic~xz~zlib,cray-sles15-zen2
+libunwind,1.5.0,gcc@10.2.0,+pic+xz~zlib,cray-sles15-zen2
+libunwind,1.5.0,gcc@10.3.0,+pic+xz~zlib,cray-sles15-zen2
+libx11,1.7.0,gcc@7.5.0,,linux-sles15-x86_64
+libxau,1.0.8,gcc@7.5.0,,linux-sles15-x86_64
+libxcb,1.14,gcc@7.5.0,,linux-sles15-x86_64
+libxdmcp,1.1.2,gcc@7.5.0,,linux-sles15-x86_64
+libxext,1.3.3,gcc@7.5.0,,linux-sles15-x86_64
+libxfixes,5.0.2,gcc@7.5.0,,linux-sles15-x86_64
+libxfont,1.5.2,gcc@7.5.0,,linux-sles15-x86_64
+libxft,2.3.2,gcc@7.5.0,,linux-sles15-x86_64
+libxi,1.7.6,gcc@7.5.0,,linux-sles15-x86_64
+libxkbcommon,0.8.2,gcc@7.5.0,,linux-sles15-x86_64
+libxkbfile,1.0.9,gcc@7.5.0,,linux-sles15-x86_64
+libxml2,2.9.10,cce@12.0.0,~python,cray-sles15-zen2
+libxml2,2.9.10,cce@12.0.1,~python,cray-sles15-zen2
+libxml2,2.9.10,gcc@7.5.0,~python,linux-sles15-x86_64
+libxml2,2.9.10,gcc@10.2.0,~python,cray-sles15-zen2
+libxml2,2.9.10,gcc@10.2.0,~python,cray-sles15-zen2
+libxml2,2.9.10,gcc@10.3.0,~python,cray-sles15-zen2
+libxml2,2.9.10,gcc@10.3.0,~python,cray-sles15-zen2
+libxpm,3.5.12,gcc@7.5.0,,linux-sles15-x86_64
+libxrandr,1.5.0,gcc@7.5.0,,linux-sles15-x86_64
+libxrender,0.9.10,gcc@7.5.0,,linux-sles15-x86_64
+libxslt,1.1.33,gcc@7.5.0,+crypto~python,linux-sles15-x86_64
+libxt,1.1.5,gcc@7.5.0,,linux-sles15-x86_64
+libxtst,1.2.2,gcc@7.5.0,,linux-sles15-x86_64
+libzmq,4.3.3,gcc@7.5.0,~drafts+libsodium,linux-sles15-x86_64
+llvm,12.0.0,gcc@7.5.0,~all_targets+clang~code_signing+compiler-rt~cuda~flang+gold+internal_unwind~ipo+libcxx+lld+lldb~llvm_dylib~mlir~omp_debug~omp_tsan+polly~python~shared_libs~split_dwarf build_type=Release cuda_arch=none,linux-sles15-x86_64
+llvm-amdgpu,4.2.0,cce@12.0.0,~ipo+openmp build_type=Release patches=d999f3b235e655ee07f6dd2590302082feaa06d32c5c6b53aae9c5cf1e45b644,cray-sles15-zen2
+llvm-amdgpu,4.2.0,cce@12.0.1,~ipo+openmp build_type=Release patches=d999f3b235e655ee07f6dd2590302082feaa06d32c5c6b53aae9c5cf1e45b644,cray-sles15-zen2
+llvm-amdgpu,4.3.0,gcc@10.2.0,~ipo+openmp build_type=Release,cray-sles15-zen2
+llvm-amdgpu,4.3.0,gcc@10.3.0,~ipo+openmp build_type=Release,cray-sles15-zen2
+lz4,1.9.3,cce@12.0.0, libs=shared,static,cray-sles15-zen2
+lz4,1.9.3,cce@12.0.1, libs=shared,static,cray-sles15-zen2
+lz4,1.9.3,gcc@7.5.0, libs=shared,static,linux-sles15-x86_64
+lz4,1.9.3,gcc@10.2.0, libs=shared,static,cray-sles15-zen2
+lz4,1.9.3,gcc@10.3.0, libs=shared,static,cray-sles15-zen2
+m4,1.4.18,cce@12.0.0,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,cray-sles15-zen2
+m4,1.4.18,cce@12.0.1,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,cray-sles15-zen2
+m4,1.4.18,gcc@7.5.0,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,linux-sles15-x86_64
+m4,1.4.18,gcc@10.2.0,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,cray-sles15-zen2
+m4,1.4.18,gcc@10.3.0,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,cray-sles15-zen2
+magma,2.6.1,cce@12.0.0,~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+magma,2.6.1,cce@12.0.1,~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+magma,2.6.1,gcc@10.2.0,~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+magma,2.6.1,gcc@10.3.0,~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+matio,1.5.17,cce@12.0.0,+hdf5+shared+zlib,cray-sles15-zen2
+matio,1.5.17,cce@12.0.1,+hdf5+shared+zlib,cray-sles15-zen2
+matio,1.5.17,gcc@10.2.0,+hdf5+shared+zlib,cray-sles15-zen2
+matio,1.5.17,gcc@10.3.0,+hdf5+shared+zlib,cray-sles15-zen2
+mbedtls,2.16.9,gcc@10.2.0,~ipo+pic build_type=Release,cray-sles15-zen2
+mbedtls,2.16.9,gcc@10.3.0,~ipo+pic build_type=Release,cray-sles15-zen2
+mercurial,5.8,gcc@7.5.0,,linux-sles15-x86_64
+mercury,2.0.1,cce@12.0.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,cray-sles15-zen2
+mercury,2.0.1,cce@12.0.1,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,cray-sles15-zen2
+mercury,2.0.1,gcc@10.2.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,cray-sles15-zen2
+mercury,2.0.1,gcc@10.3.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,cray-sles15-zen2
+mesa,21.0.3,gcc@7.5.0,+glx+llvm+opengl~opengles+osmesa~strip buildtype=debugoptimized default_library=shared patches=36096a178070e40217945e12d542dfe80016cb897284a01114d616656c577d73 swr=auto,linux-sles15-x86_64
+meson,0.58.0,gcc@7.5.0, patches=aa6c50d5a2aeb1a487d16f6712be4357fefb923aae37ab830699b07338388287,linux-sles15-x86_64
+metis,5.1.0,cce@12.0.0,~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,cray-sles15-zen2
+metis,5.1.0,cce@12.0.1,~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,cray-sles15-zen2
+metis,5.1.0,gcc@10.2.0,~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2,cray-sles15-zen2
+metis,5.1.0,gcc@10.3.0,~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2,cray-sles15-zen2
+mfem,4.2.0,cce@12.0.0,~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto,cray-sles15-zen2
+mfem,4.2.0,cce@12.0.1,~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto,cray-sles15-zen2
+mfem,4.2.0,gcc@10.2.0,~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto,cray-sles15-zen2
+mfem,4.2.0,gcc@10.3.0,~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto,cray-sles15-zen2
+mkfontdir,1.0.7,gcc@7.5.0,,linux-sles15-x86_64
+mkfontscale,1.1.2,gcc@7.5.0,,linux-sles15-x86_64
+mpark-variant,1.4.0,cce@12.0.0,~ipo build_type=RelWithDebInfo patches=21a4f8de3525204ee6db2e53758a3e3fd9c13817df29d2926d24376858a369e7,4e173fe8c853eb92956a40371688b4a19498189fe65b7ceac30f6b9d6663a985,b3501f726fd40129b4aaa11453a5891c8953a34af8ac84f5ab10a22afa5e7b9b,cray-sles15-zen2
+mpark-variant,1.4.0,cce@12.0.1,~ipo build_type=RelWithDebInfo patches=21a4f8de3525204ee6db2e53758a3e3fd9c13817df29d2926d24376858a369e7,4e173fe8c853eb92956a40371688b4a19498189fe65b7ceac30f6b9d6663a985,b3501f726fd40129b4aaa11453a5891c8953a34af8ac84f5ab10a22afa5e7b9b,cray-sles15-zen2
+mpark-variant,1.4.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo patches=21a4f8de3525204ee6db2e53758a3e3fd9c13817df29d2926d24376858a369e7,4e173fe8c853eb92956a40371688b4a19498189fe65b7ceac30f6b9d6663a985,b3501f726fd40129b4aaa11453a5891c8953a34af8ac84f5ab10a22afa5e7b9b,cray-sles15-zen2
+mpark-variant,1.4.0,gcc@10.3.0,~ipo build_type=RelWithDebInfo patches=21a4f8de3525204ee6db2e53758a3e3fd9c13817df29d2926d24376858a369e7,4e173fe8c853eb92956a40371688b4a19498189fe65b7ceac30f6b9d6663a985,b3501f726fd40129b4aaa11453a5891c8953a34af8ac84f5ab10a22afa5e7b9b,cray-sles15-zen2
+mpfr,4.1.0,cce@12.0.0,,cray-sles15-zen2
+mpfr,4.1.0,cce@12.0.1,,cray-sles15-zen2
+mpfr,4.1.0,gcc@7.5.0,,linux-sles15-x86_64
+mpfr,4.1.0,gcc@10.2.0,,cray-sles15-zen2
+mpfr,4.1.0,gcc@10.3.0,,cray-sles15-zen2
+mumps,5.4.0,cce@12.0.0,~blr_mt+complex+double+float~int64~metis+mpi+openmp~parmetis~ptscotch~scotch+shared patches=1946864d2106f7414aaa4dbd4dbc068b7804af7c1588381e814b268a56140a52,cray-sles15-zen2
+mumps,5.4.0,cce@12.0.1,~blr_mt+complex+double+float~int64~metis+mpi+openmp~parmetis~ptscotch~scotch+shared patches=1946864d2106f7414aaa4dbd4dbc068b7804af7c1588381e814b268a56140a52,cray-sles15-zen2
+mumps,5.4.0,gcc@10.2.0,~blr_mt+complex+double+float~int64~metis+mpi+openmp~parmetis~ptscotch~scotch+shared patches=1946864d2106f7414aaa4dbd4dbc068b7804af7c1588381e814b268a56140a52,cray-sles15-zen2
+mumps,5.4.0,gcc@10.3.0,~blr_mt+complex+double+float~int64~metis+mpi+openmp~parmetis~ptscotch~scotch+shared patches=1946864d2106f7414aaa4dbd4dbc068b7804af7c1588381e814b268a56140a52,cray-sles15-zen2
+nano,4.9,gcc@7.5.0,,linux-sles15-x86_64
+nasm,2.15.05,gcc@7.5.0,,linux-sles15-x86_64
+ncurses,6.2,cce@12.0.0,~symlinks+termlib abi=none,cray-sles15-zen2
+ncurses,6.2,cce@12.0.1,~symlinks+termlib abi=none,cray-sles15-zen2
+ncurses,6.2,gcc@7.5.0,~symlinks+termlib abi=none,linux-sles15-x86_64
+ncurses,6.2,gcc@10.2.0,~symlinks+termlib abi=none,cray-sles15-zen2
+ncurses,6.2,gcc@10.3.0,~symlinks+termlib abi=none,cray-sles15-zen2
+netcdf-c,4.8.0,cce@12.0.0,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,cray-sles15-zen2
+netcdf-c,4.8.0,cce@12.0.1,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,cray-sles15-zen2
+netcdf-c,4.8.0,gcc@10.2.0,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,cray-sles15-zen2
+netcdf-c,4.8.0,gcc@10.3.0,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,cray-sles15-zen2
+netlib-scalapack,2.1.0,gcc@10.2.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,cray-sles15-zen2
+netlib-scalapack,2.1.0,gcc@10.3.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,cray-sles15-zen2
+ninja,1.10.2,cce@12.0.0,,cray-sles15-zen2
+ninja,1.10.2,cce@12.0.1,,cray-sles15-zen2
+ninja,1.10.2,gcc@7.5.0,,linux-sles15-x86_64
+ninja,1.10.2,gcc@10.2.0,,cray-sles15-zen2
+ninja,1.10.2,gcc@10.3.0,,cray-sles15-zen2
+nlohmann-json,3.9.1,cce@12.0.0,~ipo+single_header build_type=RelWithDebInfo,cray-sles15-zen2
+nlohmann-json,3.9.1,cce@12.0.1,~ipo+single_header build_type=RelWithDebInfo,cray-sles15-zen2
+nlohmann-json,3.9.1,gcc@10.2.0,~ipo+single_header build_type=RelWithDebInfo,cray-sles15-zen2
+nlohmann-json,3.9.1,gcc@10.3.0,~ipo+single_header build_type=RelWithDebInfo,cray-sles15-zen2
+npth,1.6,gcc@7.5.0,,linux-sles15-x86_64
+numactl,2.0.14,cce@12.0.0, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,cray-sles15-zen2
+numactl,2.0.14,cce@12.0.1, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,cray-sles15-zen2
+numactl,2.0.14,gcc@10.2.0, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,cray-sles15-zen2
+numactl,2.0.14,gcc@10.3.0, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,cray-sles15-zen2
+omega-h,9.32.5,cce@12.0.0,~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo,cray-sles15-zen2
+omega-h,9.32.5,cce@12.0.1,~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo,cray-sles15-zen2
+omega-h,9.32.5,gcc@10.2.0,~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo,cray-sles15-zen2
+omega-h,9.32.5,gcc@10.3.0,~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo,cray-sles15-zen2
+openblas,0.3.15,gcc@10.2.0,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=none,cray-sles15-zen2
+openblas,0.3.15,gcc@10.3.0,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=none,cray-sles15-zen2
+openjdk,11.0.8_10,cce@12.0.0,,cray-sles15-zen2
+openjdk,11.0.8_10,cce@12.0.1,,cray-sles15-zen2
+openjdk,11.0.8_10,gcc@10.2.0,,cray-sles15-zen2
+openjdk,11.0.8_10,gcc@10.3.0,,cray-sles15-zen2
+openpmd-api,0.13.4,cce@12.0.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,cray-sles15-zen2
+openpmd-api,0.13.4,cce@12.0.1,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,cray-sles15-zen2
+openpmd-api,0.13.4,gcc@10.2.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,cray-sles15-zen2
+openpmd-api,0.13.4,gcc@10.3.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,cray-sles15-zen2
+openssh,8.5p1,cce@12.0.0,,cray-sles15-zen2
+openssh,8.5p1,cce@12.0.1,,cray-sles15-zen2
+openssh,8.5p1,gcc@7.5.0,,linux-sles15-x86_64
+openssh,8.5p1,gcc@10.2.0,,cray-sles15-zen2
+openssh,8.5p1,gcc@10.3.0,,cray-sles15-zen2
+openssl,1.1.1,cce@12.0.0,~docs+systemcerts,cray-sles15-zen2
+openssl,1.1.1,cce@12.0.1,~docs+systemcerts,cray-sles15-zen2
+openssl,1.1.1,gcc@7.5.0,~docs+systemcerts,linux-sles15-x86_64
+openssl,1.1.1,gcc@10.2.0,~docs+systemcerts,cray-sles15-zen2
+openssl,1.1.1,gcc@10.3.0,~docs+systemcerts,cray-sles15-zen2
+pango,1.41.0,gcc@7.5.0,~X,linux-sles15-x86_64
+pango,1.41.0,gcc@7.5.0,+X,linux-sles15-x86_64
+papi,6.0.0.1,cce@12.0.0,~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools patches=b6d6caa8c66a6495a24f32ba444e46f61e85083146dfa73ee3c8cf91fcfb4458,cray-sles15-zen2
+papi,6.0.0.1,cce@12.0.1,~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools patches=b6d6caa8c66a6495a24f32ba444e46f61e85083146dfa73ee3c8cf91fcfb4458,cray-sles15-zen2
+papi,6.0.0.1,gcc@7.5.0,~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,linux-sles15-x86_64
+papi,6.0.0.1,gcc@10.2.0,~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,cray-sles15-zen2
+papi,6.0.0.1,gcc@10.3.0,~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,cray-sles15-zen2
+papyrus,1.0.1,cce@12.0.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+papyrus,1.0.1,cce@12.0.1,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+papyrus,1.0.1,gcc@10.2.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+papyrus,1.0.1,gcc@10.3.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+parallel-netcdf,1.12.2,cce@12.0.0,~burstbuffer+cxx+fortran+pic+shared,cray-sles15-zen2
+parallel-netcdf,1.12.2,cce@12.0.1,~burstbuffer+cxx+fortran+pic+shared,cray-sles15-zen2
+parallel-netcdf,1.12.2,gcc@10.2.0,~burstbuffer+cxx+fortran+pic+shared,cray-sles15-zen2
+parallel-netcdf,1.12.2,gcc@10.3.0,~burstbuffer+cxx+fortran+pic+shared,cray-sles15-zen2
+parmetis,4.0.3,cce@12.0.0,~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d,cray-sles15-zen2
+parmetis,4.0.3,cce@12.0.1,~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d,cray-sles15-zen2
+parmetis,4.0.3,gcc@10.2.0,~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d,cray-sles15-zen2
+parmetis,4.0.3,gcc@10.3.0,~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d,cray-sles15-zen2
+pcre,8.44,cce@12.0.0,~jit+multibyte+utf,cray-sles15-zen2
+pcre,8.44,cce@12.0.1,~jit+multibyte+utf,cray-sles15-zen2
+pcre,8.44,gcc@7.5.0,~jit+multibyte+utf,linux-sles15-x86_64
+pcre,8.44,gcc@10.2.0,~jit+multibyte+utf,cray-sles15-zen2
+pcre,8.44,gcc@10.3.0,~jit+multibyte+utf,cray-sles15-zen2
+pcre2,10.36,cce@12.0.0,~jit+multibyte,cray-sles15-zen2
+pcre2,10.36,cce@12.0.1,~jit+multibyte,cray-sles15-zen2
+pcre2,10.36,gcc@7.5.0,~jit+multibyte,linux-sles15-x86_64
+pcre2,10.36,gcc@10.2.0,~jit+multibyte,cray-sles15-zen2
+pcre2,10.36,gcc@10.3.0,~jit+multibyte,cray-sles15-zen2
+pdt,3.25.1,cce@12.0.0,~pic patches=113fca02f74cc49dc1add0f617a4bada116a999a1664598380e5e7652c8c231a,cray-sles15-zen2
+pdt,3.25.1,cce@12.0.1,~pic patches=113fca02f74cc49dc1add0f617a4bada116a999a1664598380e5e7652c8c231a,cray-sles15-zen2
+pdt,3.25.1,gcc@10.2.0,~pic,cray-sles15-zen2
+pdt,3.25.1,gcc@10.3.0,~pic,cray-sles15-zen2
+perl,5.32.1,cce@12.0.0,+cpanm+shared+threads,cray-sles15-zen2
+perl,5.32.1,cce@12.0.1,+cpanm+shared+threads,cray-sles15-zen2
+perl,5.32.1,gcc@7.5.0,+cpanm+shared+threads,linux-sles15-x86_64
+perl,5.32.1,gcc@10.2.0,+cpanm+shared+threads,cray-sles15-zen2
+perl,5.32.1,gcc@10.3.0,+cpanm+shared+threads,cray-sles15-zen2
+perl-data-dumper,2.173,gcc@7.5.0,,linux-sles15-x86_64
+perl-encode-locale,1.05,gcc@7.5.0,,linux-sles15-x86_64
+perl-extutils-config,0.008,gcc@7.5.0,,linux-sles15-x86_64
+perl-extutils-helpers,0.026,gcc@7.5.0,,linux-sles15-x86_64
+perl-extutils-installpaths,0.012,gcc@7.5.0,,linux-sles15-x86_64
+perl-file-listing,6.04,gcc@7.5.0,,linux-sles15-x86_64
+perl-html-parser,3.72,gcc@7.5.0,,linux-sles15-x86_64
+perl-html-tagset,3.20,gcc@7.5.0,,linux-sles15-x86_64
+perl-http-cookies,6.04,gcc@7.5.0,,linux-sles15-x86_64
+perl-http-daemon,6.01,gcc@7.5.0,,linux-sles15-x86_64
+perl-http-date,6.02,gcc@7.5.0,,linux-sles15-x86_64
+perl-http-message,6.13,gcc@7.5.0,,linux-sles15-x86_64
+perl-http-negotiate,6.01,gcc@7.5.0,,linux-sles15-x86_64
+perl-io-html,1.001,gcc@7.5.0,,linux-sles15-x86_64
+perl-libwww-perl,6.33,gcc@7.5.0,,linux-sles15-x86_64
+perl-lwp-mediatypes,6.02,gcc@7.5.0,,linux-sles15-x86_64
+perl-module-build,0.4224,gcc@7.5.0,,linux-sles15-x86_64
+perl-module-build-tiny,0.039,gcc@7.5.0,,linux-sles15-x86_64
+perl-net-http,6.17,gcc@7.5.0,,linux-sles15-x86_64
+perl-test-needs,0.002005,gcc@7.5.0,,linux-sles15-x86_64
+perl-try-tiny,0.28,gcc@7.5.0,,linux-sles15-x86_64
+perl-uri,1.72,gcc@7.5.0,,linux-sles15-x86_64
+perl-www-robotrules,6.02,gcc@7.5.0,,linux-sles15-x86_64
+perl-xml-parser,2.44,gcc@7.5.0,,linux-sles15-x86_64
+petsc,3.15.0,gcc@10.2.0,~X+batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,cray-sles15-zen2
+petsc,3.15.0,gcc@10.3.0,~X+batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,cray-sles15-zen2
+pfunit,3.3.3,cce@12.0.0,~docs~ipo~mpi~openmp+shared~use_comm_world build_type=RelWithDebInfo max_array_rank=5,cray-sles15-zen2
+pfunit,3.3.3,cce@12.0.1,~docs~ipo~mpi~openmp+shared~use_comm_world build_type=RelWithDebInfo max_array_rank=5,cray-sles15-zen2
+pfunit,3.3.3,gcc@10.2.0,~docs~ipo~mpi~openmp+shared~use_comm_world build_type=RelWithDebInfo max_array_rank=5,cray-sles15-zen2
+pfunit,3.3.3,gcc@10.3.0,~docs~ipo~mpi~openmp+shared~use_comm_world build_type=RelWithDebInfo max_array_rank=5,cray-sles15-zen2
+pinentry,1.1.1,gcc@7.5.0,,linux-sles15-x86_64
+pixman,0.40.0,gcc@7.5.0,,linux-sles15-x86_64
+pkgconf,1.7.4,cce@12.0.0,,cray-sles15-zen2
+pkgconf,1.7.4,cce@12.0.1,,cray-sles15-zen2
+pkgconf,1.7.4,gcc@7.5.0,,linux-sles15-x86_64
+pkgconf,1.7.4,gcc@10.2.0,,cray-sles15-zen2
+pkgconf,1.7.4,gcc@10.3.0,,cray-sles15-zen2
+precice,2.2.1,gcc@10.2.0,~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo,cray-sles15-zen2
+precice,2.2.1,gcc@10.3.0,~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo,cray-sles15-zen2
+pumi,2.2.5,cce@12.0.0,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,cray-sles15-zen2
+pumi,2.2.5,cce@12.0.1,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,cray-sles15-zen2
+pumi,2.2.5,gcc@10.2.0,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,cray-sles15-zen2
+pumi,2.2.5,gcc@10.3.0,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,cray-sles15-zen2
+py-certifi,2020.6.20,gcc@7.5.0,,linux-sles15-x86_64
+py-docutils,0.15.2,gcc@7.5.0,,linux-sles15-x86_64
+py-mako,1.1.4,gcc@7.5.0,,linux-sles15-x86_64
+py-markupsafe,1.1.1,gcc@7.5.0,,linux-sles15-x86_64
+py-pyelftools,0.26,cce@12.0.0,,cray-sles15-zen2
+py-pyelftools,0.26,cce@12.0.1,,cray-sles15-zen2
+py-pyelftools,0.26,gcc@10.2.0,,cray-sles15-zen2
+py-pyelftools,0.26,gcc@10.3.0,,cray-sles15-zen2
+py-pygments,2.6.1,gcc@7.5.0,,linux-sles15-x86_64
+py-setuptools,50.3.2,cce@12.0.0,,cray-sles15-zen2
+py-setuptools,50.3.2,cce@12.0.1,,cray-sles15-zen2
+py-setuptools,50.3.2,gcc@7.5.0,,linux-sles15-x86_64
+py-setuptools,50.3.2,gcc@10.2.0,,cray-sles15-zen2
+py-setuptools,50.3.2,gcc@10.3.0,,cray-sles15-zen2
+py-toml,0.10.2,cce@12.0.0,,cray-sles15-zen2
+py-toml,0.10.2,cce@12.0.1,,cray-sles15-zen2
+py-toml,0.10.2,gcc@10.2.0,,cray-sles15-zen2
+py-toml,0.10.2,gcc@10.3.0,,cray-sles15-zen2
+python,3.8.10,gcc@7.5.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,linux-sles15-x86_64
+python,3.8.10,cce@12.0.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,ebdca648c9c1d25f586d7e2a495b62e6d91973b55264a13d89eda1beff72ef56,cray-sles15-zen2
+python,3.8.10,cce@12.0.1,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,ebdca648c9c1d25f586d7e2a495b62e6d91973b55264a13d89eda1beff72ef56,cray-sles15-zen2
+python,3.8.10,gcc@10.2.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,ebdca648c9c1d25f586d7e2a495b62e6d91973b55264a13d89eda1beff72ef56,cray-sles15-zen2
+python,3.8.10,gcc@10.2.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,ebdca648c9c1d25f586d7e2a495b62e6d91973b55264a13d89eda1beff72ef56,cray-sles15-zen2
+python,3.8.10,gcc@10.3.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,ebdca648c9c1d25f586d7e2a495b62e6d91973b55264a13d89eda1beff72ef56,cray-sles15-zen2
+python,3.8.10,gcc@10.3.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,ebdca648c9c1d25f586d7e2a495b62e6d91973b55264a13d89eda1beff72ef56,cray-sles15-zen2
+python,3.8.10,gcc@7.5.0,+bz2+ctypes+dbm+debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,linux-sles15-x86_64
+qthreads,1.16,cce@12.0.0,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,cray-sles15-zen2
+qthreads,1.16,cce@12.0.1,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,cray-sles15-zen2
+qthreads,1.16,gcc@10.2.0,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,cray-sles15-zen2
+qthreads,1.16,gcc@10.3.0,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,cray-sles15-zen2
+raja,0.13.0,cce@12.0.0,~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+raja,0.13.0,cce@12.0.1,~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+raja,0.13.0,gcc@10.2.0,~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+raja,0.13.0,gcc@10.3.0,~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+randrproto,1.5.0,gcc@7.5.0,,linux-sles15-x86_64
+readline,8.1,cce@12.0.0,,cray-sles15-zen2
+readline,8.1,cce@12.0.1,,cray-sles15-zen2
+readline,8.1,gcc@7.5.0,,linux-sles15-x86_64
+readline,8.1,gcc@10.2.0,,cray-sles15-zen2
+readline,8.1,gcc@10.3.0,,cray-sles15-zen2
+recordproto,1.14.2,gcc@7.5.0,,linux-sles15-x86_64
+renderproto,0.11.1,gcc@7.5.0,,linux-sles15-x86_64
+rocblas,4.2.0,cce@12.0.0,~ipo build_type=RelWithDebInfo tensile_architecture=all,cray-sles15-zen2
+rocblas,4.2.0,cce@12.0.1,~ipo build_type=RelWithDebInfo tensile_architecture=all,cray-sles15-zen2
+rocblas,4.3.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo tensile_architecture=all,cray-sles15-zen2
+rocblas,4.3.0,gcc@10.3.0,~ipo build_type=RelWithDebInfo tensile_architecture=all,cray-sles15-zen2
+rocsolver,4.2.0,cce@12.0.0,~ipo+optimal build_type=RelWithDebInfo,cray-sles15-zen2
+rocsolver,4.2.0,cce@12.0.1,~ipo+optimal build_type=RelWithDebInfo,cray-sles15-zen2
+rocsolver,4.3.0,gcc@10.2.0,~ipo+optimal build_type=RelWithDebInfo,cray-sles15-zen2
+rocsolver,4.3.0,gcc@10.3.0,~ipo+optimal build_type=RelWithDebInfo,cray-sles15-zen2
+rocsparse,4.2.0,cce@12.0.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+rocsparse,4.2.0,cce@12.0.1,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+rocsparse,4.3.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+rocsparse,4.3.0,gcc@10.3.0,~ipo build_type=RelWithDebInfo,cray-sles15-zen2
+rust,1.51.0,gcc@7.5.0,+analysis+clippy~rls+rustfmt+src extra_targets=none,linux-sles15-x86_64
+scons,3.1.2,gcc@7.5.0,,linux-sles15-x86_64
+screen,4.8.0,gcc@7.5.0, patches=755de623439b654453801dbbb09cce0f3f889a12ad1a060bf57147d5b2b5c295,linux-sles15-x86_64
+serf,1.3.9,gcc@7.5.0,~debug patches=b6593a4dafea97d1bef13b5d57fecb1410f02452d7def51b31f76bf76a85c4ad,linux-sles15-x86_64
+shared-mime-info,1.9,gcc@7.5.0,,linux-sles15-x86_64
+slate,2021.05.02,gcc@10.2.0,~cuda~ipo+mpi+openmp+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+slate,2021.05.02,gcc@10.3.0,~cuda~ipo+mpi+openmp+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+slepc,3.15.0,gcc@10.2.0,+arpack~blopex,cray-sles15-zen2
+slepc,3.15.0,gcc@10.3.0,+arpack~blopex,cray-sles15-zen2
+snappy,1.1.8,cce@12.0.0,~ipo+pic+shared build_type=RelWithDebInfo patches=c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd,cray-sles15-zen2
+snappy,1.1.8,cce@12.0.1,~ipo+pic+shared build_type=RelWithDebInfo patches=c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd,cray-sles15-zen2
+snappy,1.1.8,gcc@10.2.0,~ipo+pic+shared build_type=RelWithDebInfo patches=c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd,cray-sles15-zen2
+snappy,1.1.8,gcc@10.3.0,~ipo+pic+shared build_type=RelWithDebInfo patches=c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd,cray-sles15-zen2
+sqlite,3.35.5,cce@12.0.0,+column_metadata+fts~functions~rtree,cray-sles15-zen2
+sqlite,3.35.5,cce@12.0.1,+column_metadata+fts~functions~rtree,cray-sles15-zen2
+sqlite,3.35.5,gcc@7.5.0,+column_metadata+fts~functions~rtree,linux-sles15-x86_64
+sqlite,3.35.5,gcc@10.2.0,+column_metadata+fts~functions~rtree,cray-sles15-zen2
+sqlite,3.35.5,gcc@10.3.0,+column_metadata+fts~functions~rtree,cray-sles15-zen2
+stc,0.9.0,cce@12.0.0,,cray-sles15-zen2
+stc,0.9.0,cce@12.0.1,,cray-sles15-zen2
+stc,0.9.0,gcc@10.2.0,,cray-sles15-zen2
+stc,0.9.0,gcc@10.3.0,,cray-sles15-zen2
+subversion,1.14.0,gcc@7.5.0,~perl+serf,linux-sles15-x86_64
+suite-sparse,5.9.0,cce@12.0.0,~cuda~openmp+pic~tbb,cray-sles15-zen2
+suite-sparse,5.9.0,cce@12.0.1,~cuda~openmp+pic~tbb,cray-sles15-zen2
+suite-sparse,5.9.0,gcc@10.2.0,~cuda~openmp+pic~tbb,cray-sles15-zen2
+suite-sparse,5.9.0,gcc@10.3.0,~cuda~openmp+pic~tbb,cray-sles15-zen2
+superlu,5.2.1,cce@12.0.0,+pic,cray-sles15-zen2
+superlu,5.2.1,cce@12.0.1,+pic,cray-sles15-zen2
+superlu,5.2.1,gcc@10.2.0,+pic,cray-sles15-zen2
+superlu,5.2.1,gcc@10.3.0,+pic,cray-sles15-zen2
+superlu-dist,6.4.0,cce@12.0.0,~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+superlu-dist,6.4.0,cce@12.0.1,~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+superlu-dist,6.4.0,gcc@10.2.0,~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+superlu-dist,6.4.0,gcc@10.3.0,~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+swig,4.0.2,cce@12.0.0,,cray-sles15-zen2
+swig,4.0.2,cce@12.0.1,,cray-sles15-zen2
+swig,4.0.2,gcc@7.5.0,,linux-sles15-x86_64
+swig,4.0.2,gcc@10.2.0,,cray-sles15-zen2
+swig,4.0.2,gcc@10.3.0,,cray-sles15-zen2
+swig,4.0.2-fortran,cce@12.0.0,,cray-sles15-zen2
+swig,4.0.2-fortran,cce@12.0.1,,cray-sles15-zen2
+swig,4.0.2-fortran,gcc@10.2.0,,cray-sles15-zen2
+swig,4.0.2-fortran,gcc@10.3.0,,cray-sles15-zen2
+sz,2.1.11.1,cce@12.0.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,cray-sles15-zen2
+sz,2.1.11.1,cce@12.0.1,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,cray-sles15-zen2
+sz,2.1.11.1,gcc@10.2.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,cray-sles15-zen2
+sz,2.1.11.1,gcc@10.3.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,cray-sles15-zen2
+tar,1.34,cce@12.0.0,,cray-sles15-zen2
+tar,1.34,cce@12.0.1,,cray-sles15-zen2
+tar,1.34,gcc@7.5.0,,linux-sles15-x86_64
+tar,1.34,gcc@10.2.0,,cray-sles15-zen2
+tar,1.34,gcc@10.3.0,,cray-sles15-zen2
+tasmanian,7.5,cce@12.0.0,~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none,cray-sles15-zen2
+tasmanian,7.5,cce@12.0.1,~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none,cray-sles15-zen2
+tasmanian,7.5,gcc@10.2.0,~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none,cray-sles15-zen2
+tasmanian,7.5,gcc@10.3.0,~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none,cray-sles15-zen2
+tcl,8.6.11,cce@12.0.0,,cray-sles15-zen2
+tcl,8.6.11,cce@12.0.1,,cray-sles15-zen2
+tcl,8.6.11,gcc@10.2.0,,cray-sles15-zen2
+tcl,8.6.11,gcc@10.3.0,,cray-sles15-zen2
+texinfo,6.5,cce@12.0.0, patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1,cray-sles15-zen2
+texinfo,6.5,cce@12.0.1, patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1,cray-sles15-zen2
+texinfo,6.5,gcc@7.5.0, patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1,linux-sles15-x86_64
+texinfo,6.5,gcc@10.2.0, patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1,cray-sles15-zen2
+texinfo,6.5,gcc@10.3.0, patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1,cray-sles15-zen2
+tmux,3.1b,gcc@7.5.0,,linux-sles15-x86_64
+trilinos,13.0.1,cce@12.0.0,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox+openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long patches=2fb1cf3f166bc339bf5c87d1e0af15ea703ffe9b21c0fe3abd788a59e56e0832,cray-sles15-zen2
+trilinos,13.0.1,cce@12.0.1,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox+openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long patches=2fb1cf3f166bc339bf5c87d1e0af15ea703ffe9b21c0fe3abd788a59e56e0832,cray-sles15-zen2
+trilinos,13.0.1,gcc@10.2.0,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox+openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long,cray-sles15-zen2
+trilinos,13.0.1,gcc@10.3.0,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox+openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long,cray-sles15-zen2
+turbine,1.3.0,cce@12.0.0,~hdf5~python~r,cray-sles15-zen2
+turbine,1.3.0,cce@12.0.1,~hdf5~python~r,cray-sles15-zen2
+turbine,1.3.0,gcc@10.2.0,~hdf5~python~r,cray-sles15-zen2
+turbine,1.3.0,gcc@10.3.0,~hdf5~python~r,cray-sles15-zen2
+umap,2.1.0,cce@12.0.0,~ipo~logging~tests build_type=RelWithDebInfo,cray-sles15-zen2
+umap,2.1.0,cce@12.0.1,~ipo~logging~tests build_type=RelWithDebInfo,cray-sles15-zen2
+umap,2.1.0,gcc@10.2.0,~ipo~logging~tests build_type=RelWithDebInfo,cray-sles15-zen2
+umap,2.1.0,gcc@10.3.0,~ipo~logging~tests build_type=RelWithDebInfo,cray-sles15-zen2
+umpire,4.1.2,cce@12.0.0,+c~cuda~deviceconst+examples~fortran~ipo~numa~openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,cray-sles15-zen2
+umpire,4.1.2,cce@12.0.1,+c~cuda~deviceconst+examples~fortran~ipo~numa~openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,cray-sles15-zen2
+umpire,4.1.2,gcc@10.2.0,+c~cuda~deviceconst+examples~fortran~ipo~numa~openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,cray-sles15-zen2
+umpire,4.1.2,gcc@10.3.0,+c~cuda~deviceconst+examples~fortran~ipo~numa~openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,cray-sles15-zen2
+utf8proc,2.4.0,gcc@7.5.0,~ipo build_type=RelWithDebInfo,linux-sles15-x86_64
+util-linux-uuid,2.36.2,cce@12.0.0,,cray-sles15-zen2
+util-linux-uuid,2.36.2,cce@12.0.1,,cray-sles15-zen2
+util-linux-uuid,2.36.2,gcc@7.5.0,,linux-sles15-x86_64
+util-linux-uuid,2.36.2,gcc@10.2.0,,cray-sles15-zen2
+util-linux-uuid,2.36.2,gcc@10.3.0,,cray-sles15-zen2
+util-macros,1.19.1,cce@12.0.0,,cray-sles15-zen2
+util-macros,1.19.1,cce@12.0.1,,cray-sles15-zen2
+util-macros,1.19.1,gcc@7.5.0,,linux-sles15-x86_64
+util-macros,1.19.1,gcc@10.2.0,,cray-sles15-zen2
+util-macros,1.19.1,gcc@10.3.0,,cray-sles15-zen2
+vim,8.2.2541,gcc@7.5.0,~big~cscope~gui~huge~lua~normal~perl~python~ruby~small~tiny~x,linux-sles15-x86_64
+wget,1.21,gcc@7.5.0,~libpsl~pcre~python+zlib ssl=openssl,linux-sles15-x86_64
+xcb-proto,1.14.1,gcc@7.5.0,,linux-sles15-x86_64
+xerces-c,3.2.3,gcc@10.2.0, cxxstd=default netaccessor=curl transcoder=iconv,cray-sles15-zen2
+xerces-c,3.2.3,gcc@10.3.0, cxxstd=default netaccessor=curl transcoder=iconv,cray-sles15-zen2
+xextproto,7.3.0,gcc@7.5.0,,linux-sles15-x86_64
+xkbcomp,1.4.4,gcc@7.5.0,,linux-sles15-x86_64
+xkbdata,1.0.1,gcc@7.5.0,,linux-sles15-x86_64
+xproto,7.0.31,gcc@7.5.0,,linux-sles15-x86_64
+xrandr,1.5.0,gcc@7.5.0,,linux-sles15-x86_64
+xtrans,1.3.5,gcc@7.5.0,,linux-sles15-x86_64
+xz,5.2.5,cce@12.0.0,~pic libs=shared,static,cray-sles15-zen2
+xz,5.2.5,cce@12.0.1,~pic libs=shared,static,cray-sles15-zen2
+xz,5.2.5,gcc@7.5.0,~pic libs=shared,static,linux-sles15-x86_64
+xz,5.2.5,gcc@10.2.0,~pic libs=shared,static,cray-sles15-zen2
+xz,5.2.5,gcc@10.3.0,~pic libs=shared,static,cray-sles15-zen2
+xz,5.2.5,gcc@10.2.0,+pic libs=shared,static,cray-sles15-zen2
+xz,5.2.5,gcc@10.3.0,+pic libs=shared,static,cray-sles15-zen2
+z3,4.8.9,gcc@7.5.0,+python,linux-sles15-x86_64
+zfp,0.5.5,cce@12.0.0,~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=64 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+zfp,0.5.5,cce@12.0.1,~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=64 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+zfp,0.5.5,gcc@10.2.0,~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=64 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+zfp,0.5.5,gcc@10.3.0,~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=64 build_type=RelWithDebInfo cuda_arch=none,cray-sles15-zen2
+zlib,1.2.11,cce@12.0.0,+optimize+pic+shared patches=e93f7400712c2814905815204dadbdebcb91dc77dd586f60cbc82efa102fb539,cray-sles15-zen2
+zlib,1.2.11,cce@12.0.1,+optimize+pic+shared patches=e93f7400712c2814905815204dadbdebcb91dc77dd586f60cbc82efa102fb539,cray-sles15-zen2
+zlib,1.2.11,gcc@7.5.0,+optimize+pic+shared,linux-sles15-x86_64
+zlib,1.2.11,gcc@10.2.0,+optimize+pic+shared,cray-sles15-zen2
+zlib,1.2.11,gcc@10.3.0,+optimize+pic+shared,cray-sles15-zen2
+zsh,5.8,cce@12.0.0,+skip-tcsetpgrp-test,cray-sles15-zen2
+zsh,5.8,cce@12.0.1,+skip-tcsetpgrp-test,cray-sles15-zen2
+zsh,5.8,gcc@10.2.0,+skip-tcsetpgrp-test,cray-sles15-zen2
+zsh,5.8,gcc@10.3.0,+skip-tcsetpgrp-test,cray-sles15-zen2
+zstd,1.5.0,cce@12.0.0,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,cray-sles15-zen2
+zstd,1.5.0,cce@12.0.1,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,cray-sles15-zen2
+zstd,1.5.0,gcc@7.5.0,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,linux-sles15-x86_64
+zstd,1.5.0,gcc@10.2.0,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,cray-sles15-zen2
+zstd,1.5.0,gcc@10.3.0,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,cray-sles15-zen2

--- a/OLCF/spock/e4s-21.05.txt
+++ b/OLCF/spock/e4s-21.05.txt
@@ -1,3 +1,4 @@
+# spack find --format "{name},{version},{compiler},{variants},{arch}"
 adiak,0.2.1,gcc@10.2.0,~ipo+mpi+shared build_type=RelWithDebInfo,cray-sles15-zen2
 adiak,0.2.1,gcc@10.3.0,~ipo+mpi+shared build_type=RelWithDebInfo,cray-sles15-zen2
 adios2,2.7.1,cce@12.0.0,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,cray-sles15-zen2

--- a/OLCF/spock/e4s-21.05.txt
+++ b/OLCF/spock/e4s-21.05.txt
@@ -1,0 +1,200 @@
+adios2@2.7.1%cce@12.0.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
+adios2@2.7.1%cce@12.0.1 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
+adios2@2.7.1%gcc@10.2.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
+adios2@2.7.1%gcc@10.3.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
+aml@0.1.0%cce@12.0.0
+aml@0.1.0%cce@12.0.1
+aml@0.1.0%gcc@10.2.0
+aml@0.1.0%gcc@10.3.0
+arborx@1.0%cce@12.0.0 ~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
+arborx@1.0%cce@12.0.1 ~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
+arborx@1.0%gcc@10.2.0 ~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
+arborx@1.0%gcc@10.3.0 ~cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
+argobots@1.1%cce@12.0.0 ~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none
+argobots@1.1%cce@12.0.1 ~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none
+argobots@1.1%gcc@10.2.0 ~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none
+argobots@1.1%gcc@10.3.0 ~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none
+bolt@2.0%cce@12.0.0 ~ipo build_type=RelWithDebInfo
+bolt@2.0%cce@12.0.1 ~ipo build_type=RelWithDebInfo
+bolt@2.0%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
+bolt@2.0%gcc@10.3.0 ~ipo build_type=RelWithDebInfo
+cabana@0.3.0%cce@12.0.0 ~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
+cabana@0.3.0%cce@12.0.1 ~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
+cabana@0.3.0%gcc@10.2.0 ~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
+cabana@0.3.0%gcc@10.3.0 ~cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
+caliper@2.5.0%gcc@10.2.0 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
+caliper@2.5.0%gcc@10.3.0 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
+ccache@4.3%gcc@7.5.0 ~ipo build_type=RelWithDebInfo
+chai@2.3.0%cce@12.0.0 ~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
+chai@2.3.0%cce@12.0.1 ~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
+chai@2.3.0%gcc@10.2.0 ~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
+chai@2.3.0%gcc@10.3.0 ~benchmarks~cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
+cmake@3.20.2%gcc@7.5.0 ~doc+ncurses+openssl+ownlibs~qt build_type=Release
+cmake@3.21.2-dev%gcc@7.5.0 ~doc+ncurses+openssl+ownlibs~qt build_type=Release
+conduit@0.7.2%cce@12.0.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
+conduit@0.7.2%cce@12.0.1 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
+conduit@0.7.2%gcc@10.2.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
+conduit@0.7.2%gcc@10.3.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
+darshan-util@3.3.0%cce@12.0.0 ~apmpi~apxc~bzip2+shared
+darshan-util@3.3.0%cce@12.0.1 ~apmpi~apxc~bzip2+shared
+darshan-util@3.3.0%gcc@7.5.0 ~apmpi~apxc~bzip2+shared
+darshan-util@3.3.0%gcc@10.2.0 ~apmpi~apxc~bzip2+shared
+darshan-util@3.3.0%gcc@10.3.0 ~apmpi~apxc~bzip2+shared
+dyninst@11.0.0%gcc@10.2.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+dyninst@11.0.0%gcc@10.3.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+emacs@27.2%gcc@7.5.0 +X~native~tls toolkit=gtk
+faodel@1.1906.1%cce@12.0.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
+faodel@1.1906.1%cce@12.0.1 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
+faodel@1.1906.1%gcc@10.2.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
+faodel@1.1906.1%gcc@10.3.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
+flecsi@1.4%cce@12.0.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
+flecsi@1.4%cce@12.0.1 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
+flecsi@1.4%gcc@10.2.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
+flecsi@1.4%gcc@10.3.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
+flit@2.1.0%cce@12.0.0
+flit@2.1.0%cce@12.0.1
+flit@2.1.0%gcc@10.2.0
+flit@2.1.0%gcc@10.3.0
+gasnet@2020.3.0%cce@12.0.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
+gasnet@2020.3.0%cce@12.0.1 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
+gasnet@2020.3.0%gcc@10.2.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
+gasnet@2020.3.0%gcc@10.3.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
+gdb@10.2%gcc@7.5.0 ~gold~ld~lto+python~quad~source-highlight~tui+xz patches=0b73f4c573768130ab59fa218cfc352d1db9678423ce787012e46e589154745c
+git@2.31.1%gcc@7.5.0 +man+nls+perl~svn~tcltk
+globalarrays@5.8%cce@12.0.0 ~scalapack armci=mpi-ts
+globalarrays@5.8%cce@12.0.1 ~scalapack armci=mpi-ts
+globalarrays@5.8%gcc@10.2.0 ~scalapack armci=mpi-ts
+globalarrays@5.8%gcc@10.3.0 ~scalapack armci=mpi-ts
+gmp@6.2.1%cce@12.0.0
+gmp@6.2.1%cce@12.0.1
+gmp@6.2.1%gcc@10.2.0
+gmp@6.2.1%gcc@10.3.0
+gnupg@2.2.19%gcc@7.5.0
+gnuplot@5.2.8%gcc@7.5.0 +X+cairo+gd+libcerf~pbm~qt~wx patches=ad89f23815fd925889ae78009ba22e6f9e4b12fea389280040cef519deafb052
+go@1.16.4%gcc@7.5.0
+googletest@1.11.0%gcc@7.5.0 ~gmock~ipo+pthreads+shared build_type=RelWithDebInfo
+gotcha@1.0.3%cce@12.0.0 ~ipo~test build_type=RelWithDebInfo
+gotcha@1.0.3%cce@12.0.1 ~ipo~test build_type=RelWithDebInfo
+gotcha@1.0.3%gcc@10.2.0 ~ipo~test build_type=RelWithDebInfo
+gotcha@1.0.3%gcc@10.3.0 ~ipo~test build_type=RelWithDebInfo
+hdf5@1.10.7%cce@12.0.1 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%gcc@10.3.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+heffte@2.0.0%cce@12.0.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
+heffte@2.0.0%cce@12.0.1 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
+heffte@2.0.0%gcc@10.2.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
+heffte@2.0.0%gcc@10.3.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
+hpctoolkit@2021.03.01%gcc@10.2.0 ~all-static~cray~cuda~mpi+papi~rocm
+hpctoolkit@2021.03.01%gcc@10.3.0 ~all-static~cray~cuda~mpi+papi~rocm
+hpx@1.6.0%cce@12.0.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.6.0%cce@12.0.1 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.6.0%gcc@10.2.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.6.0%gcc@10.3.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+htop@3.0.2%gcc@7.5.0 +unicode
+hypre@2.20.0%cce@12.0.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%cce@12.0.1 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%gcc@10.2.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%gcc@10.3.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+imagemagick@7.0.8-7%gcc@7.5.0
+kokkos@3.4.00%cce@12.0.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14
+kokkos@3.4.00%cce@12.0.1 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14
+kokkos@3.4.00%gcc@10.2.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14
+kokkos@3.4.00%gcc@10.3.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread+rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none std=14
+kokkos@3.4.00%cce@12.0.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14
+kokkos@3.4.00%cce@12.0.1 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14
+kokkos@3.4.00%gcc@10.2.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14
+kokkos@3.4.00%gcc@10.3.0 ~aggressive_vectorization~compiler_warnings~cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning~wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none std=14
+kokkos-kernels@3.2.00%cce@12.0.0 ~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
+kokkos-kernels@3.2.00%cce@12.0.1 ~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
+kokkos-kernels@3.2.00%gcc@10.2.0 ~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
+kokkos-kernels@3.2.00%gcc@10.3.0 ~blas~cblas~cublas~cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=none execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
+legion@21.03.0%cce@12.0.0 ~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+legion@21.03.0%cce@12.0.1 ~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+legion@21.03.0%gcc@10.2.0 ~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+legion@21.03.0%gcc@10.3.0 ~bindings~bounds_checks~cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug~hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+libpng@1.2.57%gcc@7.5.0
+libquo@1.3.1%cce@12.0.0
+libquo@1.3.1%cce@12.0.1
+libquo@1.3.1%gcc@10.2.0
+libquo@1.3.1%gcc@10.3.0
+libzmq@4.3.3%gcc@7.5.0 ~drafts+libsodium
+magma@2.6.1%cce@12.0.0 ~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
+magma@2.6.1%cce@12.0.1 ~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
+magma@2.6.1%gcc@10.2.0 ~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
+magma@2.6.1%gcc@10.3.0 ~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
+mercurial@5.8%gcc@7.5.0
+mercury@2.0.1%cce@12.0.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.1%cce@12.0.1 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.1%gcc@10.2.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.1%gcc@10.3.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mfem@4.2.0%cce@12.0.0 ~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto
+mfem@4.2.0%cce@12.0.1 ~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto
+mfem@4.2.0%gcc@10.2.0 ~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto
+mfem@4.2.0%gcc@10.3.0 ~amgx~conduit~cuda~debug~examples~gnutls~gslib~lapack~libceed~libunwind+metis~miniapps~mpfr+mpi~netcdf~occa~openmp~petsc~pumi~raja~shared+static~strumpack~suite-sparse~sundials~superlu-dist~threadsafe~umpire+zlib cuda_arch=sm_60 timer=auto
+nano@4.9%gcc@7.5.0
+ninja@1.10.2%gcc@10.2.0
+omega-h@9.32.5%cce@12.0.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
+omega-h@9.32.5%cce@12.0.1 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
+omega-h@9.32.5%gcc@10.2.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
+omega-h@9.32.5%gcc@10.3.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
+openpmd-api@0.13.4%cce@12.0.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.4%cce@12.0.1 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.4%gcc@10.2.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.4%gcc@10.3.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+papi@6.0.0.1%cce@12.0.0 ~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools patches=b6d6caa8c66a6495a24f32ba444e46f61e85083146dfa73ee3c8cf91fcfb4458
+papi@6.0.0.1%cce@12.0.1 ~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools patches=b6d6caa8c66a6495a24f32ba444e46f61e85083146dfa73ee3c8cf91fcfb4458
+papi@6.0.0.1%gcc@7.5.0 ~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools
+papyrus@1.0.1%cce@12.0.0 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.1%cce@12.0.1 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.1%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.1%gcc@10.3.0 ~ipo build_type=RelWithDebInfo
+pdt@3.25.1%cce@12.0.0 ~pic patches=113fca02f74cc49dc1add0f617a4bada116a999a1664598380e5e7652c8c231a
+pdt@3.25.1%cce@12.0.1 ~pic patches=113fca02f74cc49dc1add0f617a4bada116a999a1664598380e5e7652c8c231a
+pdt@3.25.1%gcc@10.2.0 ~pic
+pdt@3.25.1%gcc@10.3.0 ~pic
+petsc@3.15.0%gcc@10.2.0 ~X+batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.15.0%gcc@10.3.0 ~X+batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+precice@2.2.1%gcc@10.2.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
+precice@2.2.1%gcc@10.3.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
+pumi@2.2.5%cce@12.0.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.5%cce@12.0.1 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.5%gcc@10.2.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.5%gcc@10.3.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+qthreads@1.16%cce@12.0.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.16%cce@12.0.1 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.16%gcc@10.2.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.16%gcc@10.3.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+raja@0.13.0%cce@12.0.0 ~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
+raja@0.13.0%cce@12.0.1 ~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
+raja@0.13.0%gcc@10.2.0 ~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
+raja@0.13.0%gcc@10.3.0 ~cuda+examples+exercises~ipo~openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none
+screen@4.8.0%gcc@7.5.0  patches=755de623439b654453801dbbb09cce0f3f889a12ad1a060bf57147d5b2b5c295
+slate@2021.05.02%gcc@10.2.0 ~cuda~ipo+mpi+openmp+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
+slate@2021.05.02%gcc@10.3.0 ~cuda~ipo+mpi+openmp+rocm+shared amdgpu_target=gfx908 build_type=RelWithDebInfo cuda_arch=none
+slepc@3.15.0%gcc@10.2.0 +arpack~blopex
+slepc@3.15.0%gcc@10.3.0 +arpack~blopex
+stc@0.9.0%cce@12.0.0
+stc@0.9.0%cce@12.0.1
+stc@0.9.0%gcc@10.2.0
+stc@0.9.0%gcc@10.3.0
+subversion@1.14.0%gcc@7.5.0 ~perl+serf
+superlu@5.2.1%cce@12.0.0 +pic
+superlu@5.2.1%cce@12.0.1 +pic
+superlu@5.2.1%gcc@10.2.0 +pic
+superlu@5.2.1%gcc@10.3.0 +pic
+swig@4.0.2%gcc@10.2.0
+swig@4.0.2-fortran%cce@12.0.0
+swig@4.0.2-fortran%cce@12.0.1
+swig@4.0.2-fortran%gcc@10.2.0
+swig@4.0.2-fortran%gcc@10.3.0
+tasmanian@7.5%cce@12.0.0 ~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none
+tasmanian@7.5%cce@12.0.1 ~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none
+tasmanian@7.5%gcc@10.2.0 ~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none
+tasmanian@7.5%gcc@10.3.0 ~blas~cuda~fortran~ipo~magma~mpi+openmp~python+rocm~xsdkflags amdgpu_target=gfx908 build_type=Release cuda_arch=none
+tmux@3.1b%gcc@7.5.0
+umap@2.1.0%cce@12.0.0 ~ipo~logging~tests build_type=RelWithDebInfo
+umap@2.1.0%cce@12.0.1 ~ipo~logging~tests build_type=RelWithDebInfo
+umap@2.1.0%gcc@10.2.0 ~ipo~logging~tests build_type=RelWithDebInfo
+umap@2.1.0%gcc@10.3.0 ~ipo~logging~tests build_type=RelWithDebInfo
+umpire@4.1.2%gcc@10.2.0 +c~cuda~deviceconst+examples~fortran~ipo~numa~openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none
+vim@8.2.2541%gcc@7.5.0 ~big~cscope~gui~huge~lua~normal~perl~python~ruby~small~tiny~x
+wget@1.21%gcc@7.5.0 ~libpsl~pcre~python+zlib ssl=openssl

--- a/OLCF/spock/spack.yaml
+++ b/OLCF/spock/spack.yaml
@@ -1,0 +1,1483 @@
+# OLCF Spock Spack Environment
+
+spack:
+  #############################################################################
+  definitions:
+  - core_compiler:
+    - '%gcc@7.5.0'
+  - gcc_compilers:
+    - '%gcc@10.3.0'
+    - '%gcc@10.2.0'
+  - cray_compilers:
+    - '%cce@12.0.1'
+    - '%cce@12.0.0'
+  - all_compilers:
+    - $gcc_compilers
+    - $cray_compilers
+  - core_packages:
+    - git
+    - htop
+    - tmux
+    - cmake
+    - cmake@3.21.2-dev
+    - wget
+    - go
+    - screen
+    - vim
+    - emacs +X
+    - nano
+    - gnuplot +X
+    - subversion
+    - mercurial
+    - ccache
+    - papi
+    - gdb
+    - libzmq
+    - libpng@1.2.57
+    - gnupg
+    - python
+    - darshan-util
+    - googletest
+    # - valgrind ~mpi~boost~ubsan
+    # - gsl
+    # - nco~mpi-deps
+    - imagemagick
+    # - r
+    # - ferret ^hdf5~mpi+cxx+fortran ^netcdf-c~mpi~parallel-netcdf ^netcdf-fortran~mpi
+    # - cdo+hdf5+netcdf ^hdf5~mpi+cxx+fortran ^fftw~mpi+openmp ^netcdf-c~mpi~parallel-netcdf
+    # - vmd
+    # - sbt
+    # - spark+hadoop
+  - e4s_20.10_packages:
+    # - adios@1.13.1 ## rejected by site
+    - adios2@2.7.1~python ## changed from v2.6.0 due to broken patch
+    - aml@0.1.0
+    - arborx@0.9-beta
+    # - axom@0.3.3 ## dependency version collision with raja/umpire/blt
+    - bolt@1.0
+    - caliper@2.4.0~libdw
+    - darshan-runtime@3.2.1
+    - darshan-util@3.2.1
+    - dyninst@10.2.1
+    - faodel@1.1906.1 #~tcmalloc
+    - flecsi@1+cinch
+    - flit@2.1.0
+    - gasnet@2020.3.0
+    # - ginkgo@1.3.0 ## @1.3.0 +rocm conflicts with ROCm 4.1.0+
+    - globalarrays@5.7
+    - gotcha@1.0.3
+    - hdf5@1.10.6+mpi ## FIXME - use cray-hdf5/ cray-hdf5-parallel
+    - hpctoolkit@2020.08.03
+    # - hpx@1.5.1 ## FIXME +rocm ## build failure; otf2 fails with unknown cray platform.
+    - hypre@2.20.0
+    - kokkos-kernels@3.2.00
+    - kokkos@3.2.00 +openmp~rocm amdgpu_target=none # v<3.4 does not support gfx908
+    - legion@20.03.0
+    # - libnrm@0.1.0 ## hard mpich dependency
+    - libquo@1.3.1
+    # - magma@2.5.4 ## cuda support only
+    - mercury@1.0.1
+    - mfem@4.1.0
+    # - mpifileutils@0.10.1 ## ^libcircle fails to determine MPI through cray wrapper
+    - ninja@1.10.1
+    # - omega-h@9.29.0 ## build failure
+    # - openmpi@3.1.6 ## rejected by site
+    - openpmd-api@0.12.0
+    - papi@6.0.0.1
+    - papyrus@1.0.0
+    - parallel-netcdf@1.12.1 ## FIXME - use cray-parallel-netcdf/1.12.1.3
+    - pdt@3.25.1
+    - petsc@3.14.0
+    - phist@1.9.1
+    # - plasma@20.9.20 ^openblas ## Fails to find correct blas under cray wrappers
+    - precice@2.1.1 #FIXME - partial spec
+    - pumi@2.2.2
+    # - py-jupyterhub@1.0.0 ## rejected by site
+    # - py-libensemble@0.7.1 ## rejected by site
+    # - py-petsc4py@3.13.0 ## rejected by site
+    - qthreads@1.14
+    - raja@0.12.1
+    # - rempi@1.1.0 ## spackage needs porting for cray wrappers
+    # - scr@2.0.0 ## libyogrt: configure: error: slurm is not in specified location!
+    - slepc@3.14.0
+    - stc@0.8.3 ## build failure
+    - strumpack@5.0.0 ^openblas threads=openmp
+    - sundials@5.4.0
+    - superlu-dist@6.3.1
+    - superlu@5.2.1
+    - swig@4.0.2
+    - swig@4.0.2-fortran
+    - sz@2.1.10
+    - tasmanian@7.3
+    # - tau@2.29.1+rocm ## build failure; otf2 dependency
+    - trilinos@13.0.0
+    # - turbine@1.2.3 ## build failure
+    - umap@2.1.0
+    - umpire@4.0.1
+    # - unifyfs@0.9.2 ## Spackage needs patching for Cray
+    # - upcxx@2020.3.0 ## Tries to build for aries network on non-aries cray
+    # - veloc@1.4 ## Fails with `error: too many arguments to function 'int AXL_Init()'`
+    - zfp@0.5.5
+  - e4s_21.02_packages:
+    # - adios@1.13.1 ## rejected by site
+    - adios2@2.7.1~python
+    - aml@0.1.0
+    # - amrex@21.02 ## CMake: Could NOT find MPI_CXX
+    - arborx@0.9-beta
+    # - axom@0.4.0 ## dependency version collision with raja/umpire/blt
+    - bolt@2.0
+    - caliper@2.5.0
+    - darshan-runtime@3.2.1
+    - darshan-util@3.2.1
+    - dyninst@10.2.1
+    - faodel@1.1906.1~tcmalloc
+    - flecsi@1.4+cinch
+    - flit@2.1.0
+    - gasnet@2020.3.0
+    # - ginkgo@1.3.0 ## @1.3.0 +rocm conflicts with ROCm 4.1.0+
+    - globalarrays@5.8
+    - gotcha@1.0.3
+    - hdf5@1.10.7+mpi ## FIXME use cray-hdf5?
+    - hpctoolkit@2020.08.03
+    - hpx@1.6.0 ## FIXME: +rocm?
+    - hypre@2.20.0
+    - kokkos-kernels@3.2.00
+    - kokkos@3.2.00 +openmp~rocm amdgpu_target=none # v<3.4 does not support gfx908
+    - legion@20.03.0
+    # - libnrm@0.1.0 ## hard mpich dependency
+    - libquo@1.3.1
+    # - magma@2.5.4 ## FIXME: +rocm? 
+    - mercury@2.0.0
+    - mfem@4.2.0
+    # - mpifileutils@0.10.1 ## ^libcircle fails to determine MPI through cray wrapper
+    - ninja@1.10.2
+    - omega-h@9.32.5
+    # - openmpi@t4.0.5 ## rejected by site
+    - openpmd-api@0.13.2
+    - papi@6.0.0.1
+    - papyrus@1.0.1
+    - parallel-netcdf@1.12.1
+    - pdt@3.25.1
+    - petsc@3.14.4 ## FIXME +rocm?
+    - phist@1.9.3
+    # - plasma@20.9.20 ^openblas ## fails to find correct blas under cray wrappers
+    - precice@2.2.0
+    - pumi@2.2.5
+    # - py-jupyterhub@1.0.0 ## rejected by site
+    # - py-libensemble@0.7.1 ## rejected by site
+    # - py-petsc4py@3.13.0 ## rejected by site
+    - qthreads@1.16 scheduler=distrib
+    - raja@0.13.0
+    # - rempi@1.1.0 ## spackage needs porting for cray wrappers
+    # - scr@2.0.0 ## libyogrt: configure: error: slurm is not in specified location!
+    - slate@2020.10.00 ~rocm amdgpu_target=none ^blaspp~rocm amdgpu_target=none ^openblas
+    - slepc@3.14.2
+    - stc@0.8.3
+    - strumpack@5.1.1 ^openblas threads=openmp
+    # - sundials@5.7.0 ## fails to find MPI through cray wrappers
+    - superlu-dist@6.4.0
+    - superlu@5.2.1
+    - swig@4.0.2-fortran
+    - sz@2.1.11.1
+    - tasmanian@7.3
+    # - tau@2.30.1+rocm ## libTAUsh-rocm-rocprofiler-gnu-papi-pthread-pdt.so cannot find cray libs
+    - trilinos@13.0.1
+    - turbine@1.3.0
+    - umap@2.1.0
+    - umpire@4.1.2 ## FIXME: various problems with btl
+    # - unifyfs@0.9.2 ## Spackage needs patching for Cray
+    # - upcxx@2020.10.0 ## Tries to build for aries network on non-aries cray
+    # - veloc@1.4 ## Fails with `error: too many arguments to function 'int AXL_Init()'`
+    - zfp@0.5.5
+  - e4s_21.05_packages:
+    # - adios@1.13.1 ## rejected by site
+    - adios2@2.7.1~python
+    - aml@0.1.0
+    # - amrex@21.05 ## CMake: Could NOT find MPI_CXX
+    - arborx@1.0
+    - archer@2.0.0
+    - argobots@1.1
+    # - ascent@0.7.1 ## failing with cce in vtk-h dependency at rocm/hsa libs
+    #                   also fails to locate MPI through the cray wrappers
+    # - axom@0.5.0 ## dependency version collision with raja/umpire/blt
+    - bolt@2.0
+    - cabana@0.3.0
+    - caliper@2.5.0
+    - chai@2.3.0
+    - conduit@0.7.2
+    - darshan-runtime@3.3.0 ## installed globally
+    - darshan-util@3.3.0 ## installed globally
+    - dyninst@11.0.0
+    - faodel@1.1906.1~tcmalloc
+    - flecsi@1.4+cinch
+    - flit@2.1.0
+    - gasnet@2020.3.0
+    # - ginkgo@1.3.0 ## @1.3.0 +rocm conflicts with ROCm 4.1.0+
+    - globalarrays@5.8
+    - gmp@6.2.1
+    - gotcha@1.0.3
+    - hdf5@1.10.7+mpi ## FIXME: use cray-hdf5?
+    - heffte@2.0.0+fftw
+    - hpctoolkit@2021.03.01
+    - hpx@1.6.0
+    - hypre@2.20.0
+    - kokkos-kernels@3.2.00
+    - kokkos@3.4.00 +openmp
+    - kokkos@3.4.00 +openmp +rocm amdgpu_target=gfx908
+    - legion@21.03.0
+    # - libnrm@0.1.0 ## hard mpich dependency
+    - libquo@1.3.1
+    - magma@2.6.1
+    - mercury@2.0.1
+    - mfem@4.2.0
+    # - mpifileutils@0.11~xattr ## ^libcircle fails to determine MPI through cray wrapper
+    - ninja@1.10.2
+    - omega-h@9.32.5
+    # - openmpi@t4.0.5 ## rejected by site
+    - openpmd-api@0.13.4
+    - papi@6.0.0.1
+    - papyrus@1.0.1
+    - parallel-netcdf@1.12.2
+    - pdt@3.25.1
+    - petsc@3.15.0 ## FIXME: +rocm?
+    # - phist@1.9.3
+    # - plasma@20.9.20 ## fails to find correct blas under cray wrappers
+    - precice@2.2.1
+    - pumi@2.2.5
+    # - py-jupyterhub@1.0.0 ## rejected by site
+    # - py-libensemble@0.7.1 ## rejected by site
+    # - py-petsc4py@3.13.0 ## rejected by site
+    - qthreads@1.16 scheduler=distrib
+    - raja@0.13.0
+    # - rempi@1.1.0 ## spackage needs porting for cray wrappers
+    # - scr@3.0rc1 ## libyogrt: configure: error: slurm is not in specified location!
+    - slate@2021.05.02 ^openblas
+    - slepc@3.15.0
+    - stc@0.9.0
+    - strumpack@5.1.1 ^openblas threads=openmp
+    # - sundials@5.7.0 ## fails to find MPI through cray wrappers
+    - superlu-dist@6.4.0
+    - superlu@5.2.1
+    - swig@4.0.2
+    - swig@4.0.2-fortran
+    - sz@2.1.11.1
+    - tasmanian@7.5 +rocm amdgpu_target=gfx908
+    # - tau@2.30.1+rocm ## libTAUsh-rocm-rocprofiler-gnu-papi-pthread-pdt.so cannot find cray libs
+    - trilinos@13.0.1
+    - turbine@1.3.0
+    - umap@2.1.0
+    # - umpire@4.1.2 ## FIXME: various problems with btl
+    # - unifyfs@0.9.2 ## Spackage needs patching for Cray
+    # - upcxx@2021.3.0 ## Tries to build for aries network on non-aries cray
+    - zfp@0.5.5
+  - core_specs:
+    - matrix:
+      - - $core_packages
+      - - $core_compiler
+      - - arch=linux-sles15-x86_64
+  - e4s_specs:
+    - matrix:
+      - - $e4s_21.05_packages
+        - $e4s_21.02_packages
+      - - '%gcc@10.2.0'
+      - - ^cray-mpich@8.1.4
+      - - ^hip@4.1.0
+      - - ^hipblas@4.1.0
+      - - ^rocblas@4.1.0
+      - - ^rocrand@4.1.0
+      - - ^rocsolver@4.1.0
+      - - ^rocsparse@4.1.0
+      - - ^rocthrust@4.1.0
+      - - arch=cray-sles15-zen2
+      exclude: 
+      # # {camp, chai, sundials, umpire} failing with cce due to
+      # #     hip/hip-rocclr --> mesa18 --> binutils failure chain 
+      # #     (needs -fPIC or text relocations?)
+      # # {netlib-scalapack, omega-h, mumps, trilinos, suite-sparse, hypre} failing with
+      # #      cce due to openblas0.3.15%cce crayftn problems (unknown CLI args?);
+      # #      might replace with cray-libsci?
+      # # TODO: find what `%cce ^matio ^hdf5` and exclude it
+      - archer%cce@11.0.4
+      - archer%gcc@10.2.0 # ^llvm@8.0.0 fails, reason unknown
+      - dyninst%cce@11.0.4
+      - hpctoolkit%cce@11.0.4
+      # - plasma%cce@11.0.4
+      - caliper%cce@11.0.4
+      # - flecsi%cce@11.0.4
+      # - ginkgo%cce@11.0.4
+      # - globalarrays%cce@11.0.4
+      # - hdf5%cce@11.0.4
+      # - hypre%cce@11.0.4
+      # - kokkos%cce@11.0.4
+      # - legion%cce@11.0.4
+      # - mfem%cce@11.0.4
+      # - omega-h@9.32.5%cce@11.0.4
+      # - openpmd-api%cce@11.0.4
+      # - parallel-netcdf%cce@11.0.4
+      # - pdt%cce@11.0.4
+      # - petsc%cce@11.0.4
+      - phist%gcc@10.2.0
+      # - phist%cce@11.0.4
+      # - precice%cce@11.0.4
+      # - raja%cce@11.0.4
+      # - slate%cce@11.0.4
+      # - slepc%cce@11.0.4
+      # - tau%cce@11.0.4
+      - strumpack%gcc+rocm
+      # - superlu%cce@11.0.4
+      # - superlu-dist%cce@11.0.4
+      # - tasmanian%cce@11.0.4
+      # - trilinos@13.0.1%cce@11.0.4
+    # - matrix:
+    #   - - $e4s_21.05_packages
+    #   - - '%gcc@10.3.0'
+    #   - - ^cray-mpich@8.1.6
+    #   - - ^hip@4.1.0
+    #   - - ^rocrand@4.1.0
+    #   - - ^rocthrust@4.1.0
+    #   - - ^hipsparse@4.1.0
+    #   - - arch=cray-sles15-zen2
+    - matrix:
+      - - $e4s_21.05_packages
+      - - '%cce@12.0.0'
+      - - ^cray-mpich@8.1.6
+      - - ^hip@4.1.0
+      - - ^hipblas@4.1.0
+      - - ^hipsparse@4.1.0
+      - - ^rocblas@4.1.0
+      - - ^rocrand@4.1.0
+      - - ^rocsolver@4.1.0
+      - - ^rocsparse@4.1.0
+      - - ^rocthrust@4.1.0
+      - - arch=cray-sles15-zen2
+      exclude:
+      - archer ## elfutils
+      - caliper ## elfutils
+      - dyninst ## os elfutils insufficient
+      - hpctoolkit ## depends on dyninst
+  - cpe21.07_specs:
+    - matrix:
+      - - $e4s_21.05_packages
+      - - '%gcc@10.3.0'
+        - '%gcc@10.2.0'
+      - - ^cray-mpich@8.1.7
+      - - ^hip@4.3.0
+      - - ^hipblas@4.3.0
+      - - ^hipsparse@4.3.0
+      - - ^rocblas@4.3.0
+      - - ^rocrand@4.3.0
+      - - ^rocsolver@4.3.0
+      - - ^rocsparse@4.3.0
+      - - ^rocthrust@4.3.0
+      - - arch=cray-sles15-zen2
+      exclude:
+      - archer%gcc # ^llvm@8.0.0 fails, reason unknown
+      - darshan-runtime # FIXME; need to build on spock or when gpfs is mounted
+      - strumpack%gcc # fails due to failure to find mpi.h
+    - matrix:
+      - - $e4s_21.05_packages
+      - - '%cce@12.0.1'
+        - '%cce@12.0.0'
+      - - ^cray-mpich@8.1.7
+      - - ^hip@4.2.0
+      - - ^hipblas@4.2.0
+      - - ^hipsparse@4.2.0
+      - - ^rocblas@4.2.0
+      - - ^rocrand@4.2.0
+      - - ^rocsolver@4.2.0
+      - - ^rocsparse@4.2.0
+      - - ^rocthrust@4.2.0
+      - - arch=cray-sles15-zen2
+      exclude:
+      - archer%cce
+      - caliper%cce
+      - darshan-runtime # FIXME; need to build on spock or when gpfs is mounted
+      - dyninst%cce ## os elfutils insufficient
+      - hpctoolkit%cce ## depends on dyninst
+      - 'petsc@3.15.0%cce@12.0.0:12.0.1'
+      - 'precice@2.2.1%cce@12.0.0:12.0.1'
+      - slate%cce ^openblas
+      - 'slepc@3.15.0%cce@12.0.0:12.0.1'
+      - strumpack%cce ^openblas
+      # '%cce ^openblas': cce cannot build openblas due to GCC CLI
+      #     args being uninterperable by cce.
+      # TODO: fix or exclude the following specs:
+      # magma%cce : fails due to
+      #     'ld: warning: libgfortran.so.5, needed by lib/libmagma.so, not found
+      #         (try using -rpath or -rpath-link)'
+      #     'ld: /opt/cray/pe/lib64/cce/libcraymath.so.1: undefined reference to
+      #         `_gfortran_erfc_scaled_r8@GFORTRAN_8'
+  specs:
+  - $core_specs
+  # - $e4s_specs
+  - $cpe21.07_specs
+  # - globalarrays@5.8%cce@11.0.4 arch=cray-sles15-zen2 ^cray-mpich@8.1.4 ^cray-libsci@21.04.1.1
+  - globalarrays@5.8%cce@12.0.1 arch=cray-sles15-zen2 ^cray-mpich@8.1.7 ^cray-libsci@21.06.1.1
+  # - scorep%gcc@9.3.0 arch=cray-sles15-zen2 # fails with 'Unknown Cray Platform'
+  #############################################################################
+  mirrors:
+    facility_builds: /sw/spock/spack-env/mirrors/builds
+    source_mirror: /sw/sources/facility-spack/source_mirror
+  repos:
+  - ${FACSPACK_CONF_COMMON}/spack/repos/olcf
+  #############################################################################
+  packages:
+    openmpi:
+      buildable: false
+      version: []
+      target: []
+      compiler: []
+      providers: {}
+    mpich:
+      version: [3.4.1]
+      target: []
+      compiler: []
+      buildable: true
+      providers: {}
+      variants: +verbs+slurm device=ch4 netmod=ofi pmi=pmi
+    cray-mpich:
+      version: [8.1.4, 8.1.6, 8.1.7]
+      externals:
+      - spec: cray-mpich@8.1.4
+        modules:
+        - cray-mpich/8.1.4
+      - spec: cray-mpich@8.1.6
+        modules:
+        - cray-mpich/8.1.6
+      - spec: cray-mpich@8.1.7
+        modules:
+        - cray-mpich/8.1.7
+      target: []
+      compiler: []
+      buildable: false
+      providers: {}
+    cray-libsci:
+      buildable: false
+      version: [21.06.1.1]
+      externals:
+      - spec: cray-libsci@21.04.1.1
+        modules:
+        - cray-libsci/21.04.1.1
+      - spec: cray-libsci@21.06.1.1
+        modules:
+        - cray-libsci/21.06.1.1
+    tcsh:
+      buildable: false
+      version: [6.20.00]
+      externals:
+      - spec: tcsh@6.20.00
+        prefix: /usr
+    hip:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: hip@4.1.0
+        prefix: /opt/rocm-4.1.0/hip
+        extra_attributes:
+          compilers:
+            # c: /opt/rocm-4.1.0/llvm/bin/clang
+            # c++: /opt/rocm-4.1.0/llvm/bin/clang++
+            hip: /opt/rocm-4.1.0/hip/bin/hipcc
+      - spec: hip@4.2.0
+        prefix: /opt/rocm-4.2.0/hip
+        extra_attributes:
+          compilers:
+            # c: /opt/rocm-4.2.0/llvm/bin/clang
+            # c++: /opt/rocm-4.2.0/llvm/bin/clang++
+            hip: /opt/rocm-4.2.0/hip/bin/hipcc
+      - spec: hip@4.3.0
+        prefix: /opt/rocm-4.3.0/hip
+        extra_attributes:
+          compilers:
+            # c: /opt/rocm-4.3.0/llvm/bin/clang
+            # c++: /opt/rocm-4.3.0/llvm/bin/clang++
+            hip: /opt/rocm-4.3.0/hip/bin/hipcc
+    hip-rocclr:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: hip-rocclr@4.1.0
+        prefix: /opt/rocm-4.1.0/rocclr
+      - spec: hip-rocclr@4.2.0
+        prefix: /opt/rocm-4.2.0/rocclr
+      - spec: hip-rocclr@4.3.0
+        prefix: /opt/rocm-4.3.0/rocclr
+    comgr:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: comgr@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: comgr@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: comgr@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocm-cmake:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocm-cmake@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocm-cmake@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocm-cmake@4.3.0
+        prefix: /opt/rocm-4.3.0
+    llvm-amdgpu:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: llvm-amdgpu@4.1.0
+        prefix: /opt/rocm-4.1.0/llvm
+        # extra_attributes:
+        #   compilers:
+        #     c: /opt/rocm-4.1.0/llvm/bin/clang
+        #     c++: /opt/rocm-4.1.0/llvm/bin/clang++
+      - spec: llvm-amdgpu@4.2.0
+        prefix: /opt/rocm-4.2.0/llvm
+        # extra_attributes:
+        #   compilers:
+        #     c: /opt/rocm-4.2.0/llvm/bin/clang
+        #     c++: /opt/rocm-4.2.0/llvm/bin/clang++
+      - spec: llvm-amdgpu@4.3.0
+        prefix: /opt/rocm-4.3.0/llvm
+        # extra_attributes:
+        #   compilers:
+        #     c: /opt/rocm-4.3.0/llvm/bin/clang
+        #     c++: /opt/rocm-4.3.0/llvm/bin/clang++
+    rocm-device-libs:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocm-device-libs@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocm-device-libs@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocm-device-libs@4.3.0
+        prefix: /opt/rocm-4.3.0
+    hsa-rocr-dev:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: hsa-rocr-dev@4.1.0
+        prefix: /opt/rocm-4.1.0
+        # extra_attributes:
+        #   compilers:
+        #     c: /opt/rocm-4.1.0/llvm/bin/clang
+        #     c++: /opt/rocm-4.1.0/llvm/bin/clang++
+      - spec: hsa-rocr-dev@4.2.0
+        prefix: /opt/rocm-4.2.0
+        # extra_attributes:
+        #   compilers:
+        #     c: /opt/rocm-4.2.0/llvm/bin/clang
+        #     c++: /opt/rocm-4.2.0/llvm/bin/clang++
+      - spec: hsa-rocr-dev@4.3.0
+        prefix: /opt/rocm-4.3.0
+        # extra_attributes:
+        #   compilers:
+        #     c: /opt/rocm-4.3.0/llvm/bin/clang
+        #     c++: /opt/rocm-4.3.0/llvm/bin/clang++
+    hsakmt-roct:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: hsakmt-roct@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: hsakmt-roct@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: hsakmt-roct@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocminfo:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocminfo@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocminfo@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocminfo@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rccl:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rccl@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rccl@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rccl@4.3.0
+        prefix: /opt/rocm-4.3.0
+    hipify-clang:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: hipify-clang@4.1.0
+        prefix: /opt/rocm-4.1.0 #FIXME
+      - spec: hipify-clang@4.2.0
+        prefix: /opt/rocm-4.2.0 #FIXME
+      - spec: hipify-clang@4.3.0
+        prefix: /opt/rocm-4.3.0 #FIXME
+    hipblas:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: hipblas@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: hipblas@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: hipblas@4.3.0
+        prefix: /opt/rocm-4.3.0
+    hipcub:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: hipcub@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: hipcub@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: hipcub@4.3.0
+        prefix: /opt/rocm-4.3.0
+    hipsparse:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: hipsparse@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: hipsparse@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: hipsparse@4.3.0
+        prefix: /opt/rocm-4.3.0
+    hipfort:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: hipfort@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: hipfort@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: hipfort@4.3.0
+        prefix: /opt/rocm-4.3.0
+    hipfft:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: hipfft@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: hipfft@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: hipfft@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocm-opencl:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocm-opencl@4.1.0
+        prefix: /opt/rocm-4.1.0/opencl
+      - spec: rocm-opencl@4.2.0
+        prefix: /opt/rocm-4.2.0/opencl
+      - spec: rocm-opencl@4.3.0
+        prefix: /opt/rocm-4.3.0/opencl
+    rocm-clang-ocl:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocm-clang-ocl@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocm-clang-ocl@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocm-clang-ocl@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocm-opencl-runtime:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocm-opencl-runtime@4.1.0
+        prefix: /opt/rocm-4.1.0/opencl
+      - spec: rocm-opencl-runtime@4.2.0
+        prefix: /opt/rocm-4.2.0/opencl
+      - spec: rocm-opencl-runtime@4.3.0
+        prefix: /opt/rocm-4.3.0/opencl
+    rocm-openmp-extras:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocm-openmp-extras@4.1.0
+        prefix: /opt/rocm-4.1.0/llvm
+      - spec: rocm-openmp-extras@4.2.0
+        prefix: /opt/rocm-4.2.0/llvm
+      - spec: rocm-openmp-extras@4.3.0
+        prefix: /opt/rocm-4.3.0/llvm
+    rocblas:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocblas@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocblas@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocblas@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocfft:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      variants: amdgpu_target=gfx908 amdgpu_target_sram_ecc=gfx908
+      buildable: false
+      externals:
+      - spec: rocfft@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocfft@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocfft@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocrand:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocrand@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocrand@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocrand@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocthrust:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocthrust@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocthrust@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocthrust@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocsolver:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocsolver@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocsolver@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocsolver@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocsparse:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocsparse@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocsparse@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocsparse@4.3.0
+        prefix: /opt/rocm-4.3.0
+    roctracer-dev:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: roctracer-dev@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: roctracer-dev@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: roctracer-dev@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocprofiler-dev:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocprofiler-dev@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocprofiler-dev@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocprofiler-dev@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocprim:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocprim@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocprim@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocprim@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocm-smi:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocmsmi@4.1.0
+        prefix: /opt/rocm-4.1.0/rocm_smi
+      - spec: rocmsmi@4.2.0
+        prefix: /opt/rocm-4.2.0/rocm_smi
+      - spec: rocmsmi@4.3.0
+        prefix: /opt/rocm-4.3.0/rocm_smi
+    rocm-smi-lib:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocm-smi-lib@4.1.0
+        prefix: /opt/rocm-4.1.0/rocm_smi
+      - spec: rocm-smi-lib@4.2.0
+        prefix: /opt/rocm-4.2.0/rocm_smi
+      - spec: rocm-smi-lib@4.3.0
+        prefix: /opt/rocm-4.3.0/rocm_smi
+    miopen-hip:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: miopen-hip@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: miopen-hip@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: miopen-hip@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocalution:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocalution@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocalution@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocalution@4.3.0
+        prefix: /opt/rocm-4.3.0
+    rocm-gdb:
+      version: [4.1.0, 4.2.0, 4.3.0]
+      buildable: false
+      externals:
+      - spec: rocm-gdb@4.1.0
+        prefix: /opt/rocm-4.1.0
+      - spec: rocm-gdb@4.2.0
+        prefix: /opt/rocm-4.2.0
+      - spec: rocm-gdb@4.3.0
+        prefix: /opt/rocm-4.3.0
+    petsc:
+      variants: +batch
+    qt:
+      variants: ~ssl
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    amrex:
+      variants: +rocm amdgpu_target=gfx908
+    axom:
+      variants: ~openmp+hdf5+umpire+raja+mpi
+    blaspp:
+      variants: ~cuda+rocm amdgpu_target=gfx908
+    chai:
+      # variants: ~benchmarks~tests+rocm amdgpu_target=gfx908
+      variants: ~benchmarks~tests~rocm amdgpu_target=none
+    ginkgo:
+      variants: +rocm amdgpu_target=gfx908
+    raja:
+      # variants: ~openmp+rocm amdgpu_target=gfx908      
+      variants: ~openmp~rocm amdgpu_target=none      
+    slate:
+      variants: +rocm amdgpu_target=gfx908
+    strumpack:
+      variants: ~slate+rocm amdgpu_target=gfx908
+    sundials:
+      variants: +rocm amdgpu_target=gfx908
+    superlu-dist:
+      variants: +rocm amdgpu_target=gfx908
+    trilinos:
+      variants: +openmp
+    umpire:
+      # variants: +rocm amdgpu_target=gfx908
+      variants: ~rocm amdgpu_target=none
+    camp:
+      # variants: +rocm amdgpu_target=gfx908
+      variants: ~rocm amdgpu_target=none
+    vtk-m:
+      variants: +hip amdgpu_target=gfx908
+    magma:
+      variants: ~cuda+rocm amdgpu_target=gfx908
+    ncurses:
+      variants: +termlib
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    slurm:
+      buildable: false
+      version: [20.11.3]
+      target: []
+      compiler: []
+      providers: {}
+      externals:
+      - spec: slurm@20.11.3
+        prefix: /usr
+    m4:
+      buildable: true
+      version: [1.4.18]
+      target: []
+      providers: {}
+      externals: []
+      compiler: []
+    darshan-runtime:
+      variants: +slurm+grouplogs logpath=/gpfs/alpine/darshan/spock
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    binutils:
+      buildable: true
+      target: []
+      providers: {}
+      compiler: []
+      variants: +libiberty
+      version: []
+    openssl:
+      buildable: false
+      version: [1.1.1]
+      target: []
+      providers: {}
+      externals:
+      - spec: openssl@1.1.1
+        prefix: /usr
+      compiler: []
+    octave:
+      variants: +magick+arpack+curl+fftw+fontconfig+freetype+glpk+gnuplot+hdf5+opengl+qhull+qrupdate+qt+readline+suitesparse+zlib
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    libtool:
+      buildable: true
+      version: [2.4.6]
+      target: []
+      providers: {}
+      compiler: []
+    libfabric:
+      version: [1.11.0.4.75, 1.11.0.3.71]
+      buildable: true
+      externals:
+      - spec: libfabric@1.11.0.3.71
+        prefix: /opt/cray/libfabric/1.11.0.3.71
+      - spec: libfabric@1.11.0.4.75
+        prefix: /opt/cray/libfabric/1.11.0.4.75
+    r:
+      variants: ~X
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    fftw:
+      variants: precision=float,double,long_double
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    hdf5:
+      variants: +hl+cxx+fortran
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    netlib-scalapack:
+      variants: +fpic
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    netcdf-c:
+      variants: ~hdf4+mpi+parallel-netcdf+shared
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    parallel-netcdf:
+      variants: +cxx+fortran+fpic
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    all:
+      buildable: true
+      version: []
+      target: [x86_64]
+      providers:
+        mpi: [mpich]
+        lapack: [openblas, cray-libsci@21.06.1.1, mkl]
+        blas: [openblas, cray-libsci@21.06.1.1, mkl]
+        scalapack: [netlib-scalapack]
+      compiler: [gcc@7.5.0, gcc]
+  # Views are managed externally; placing them here triggers a regneration each
+  # time the env is re-concretized which both destroys non-spack files (eg
+  # symlinks) in "hybrid views" and removes previous builds slated to be
+  # re-built from the production view when we want to minimize disruption to
+  # users. See $FACSPACK_CONF_ENV/view-generate-*.sh scripts for managing views.
+  view: false
+  modules:
+    enable:
+    - lmod
+    - tcl
+    prefix_inspections:
+      bin:
+        - PATH
+      man:
+        - MANPATH
+      share/man:
+        - MANPATH
+      share/aclocal:
+        - ACLOCAL_PATH
+      lib:
+        - LD_LIBRARY_PATH
+      lib64:
+        - LD_LIBRARY_PATH
+      lib/pkgconfig:
+        - PKG_CONFIG_PATH
+      lib64/pkgconfig:
+        - PKG_CONFIG_PATH
+      share/pkgconfig:
+        - PKG_CONFIG_PATH
+      '':
+        - CMAKE_PREFIX_PATH
+    lmod:
+      core_compilers: [gcc@7.5.0]
+      all:
+        # suffixes:
+        #   ^python@2.0:2.99: py2
+        #   ^python@3.0:3.99: py3
+        environment:
+          set:
+            OLCF_${PACKAGE}_ROOT: ${PREFIX}
+          unset: []
+        filter:
+          environment_blacklist: []
+        load: []
+        conflict: []
+      openmpi:
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      openblas:
+        suffixes:
+          openblas threads=openmp: omp
+          openblas threads=pthreads: pthreads
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      fftw:
+        suffixes:
+          fftw+openmp: omp
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      hdf5:
+        suffixes:
+          hdf5~mpi+szip: sz
+          hdf5~mpi+threadsafe: threadsafe
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      cdo:
+        suffixes:
+          cdo^hdf5+mpi^netcdf+mpi^fftw+mpi: parallel
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      cairo:
+        suffixes:
+          cairo+X: X
+          cairo+pdf: pdf
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      gromacs:
+        suffixes:
+          gromacs~rdtscp: rdtscp_off
+          gromacs~mpi: analysis
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      vtk:
+        suffixes:
+          vtk+mpi: parallel
+          vtk~mpi: serial
+          vtk+qt: qt
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      ferret:
+        suffixes:
+          ferret^hdf5+mpi^netcdf+mpi: parallel
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      ncl:
+        suffixes:
+          builtin.ncl ^hdf5+mpi^netcdf+mpi: parallel
+          olcf.ncl: serial
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      pango:
+        suffixes:
+          pango+X: X
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      blacklist_implicits: false
+      verbose: true
+      whitelist: []
+      blacklist:
+      - binutils
+      - boost%gcc cxxstd=98
+      - camp~rocm #FIXME suffix
+      - dyninst%gcc ^elfutils+bzip2
+      - elfutils+bzip2
+      - gasnet~pshm
+      - gettext
+      - kokkos~rocm
+      - libunwind+xz
+      - libxml2 ^xz~pic
+      - xz~pic
+      - z3 ^libuuid
+      - gobject-introspection ^cairo+X # FIXME suffix
+      ###
+      - berkeley-db
+      - cray-mpich
+      - glib
+      - glproto
+      - go-bootstrap
+      - help2man
+      - inputproto
+      - kbproto
+      - libassuan
+      - libfabric
+      - libfontenc
+      - libgcrypt
+      - libgd
+      - libgpg-error
+      - libiconv
+      - libidn2
+      - libksba
+      - libpciaccess
+      - libpthread-stubs
+      - libsigsegv
+      - libsodium
+      - libunistring
+      - libuuid
+      - libx11
+      - libxau
+      - libxcb
+      - libxdmcp
+      - libxext
+      - libxfont
+      - libxpm 
+      - libxslt
+      - lua
+      - m4
+      - meson
+      - mkfontdir
+      - mkfontscale
+      - mpfr
+      - mpich
+      - msgpack-c
+      - nasm
+      - ncurses
+      - npth
+      - numactl
+      - openssh
+      - openssl
+      - pinentry
+      - pkgconf
+      - popt
+      - py-certifi
+      - py-docutils
+      - py-mako
+      - py-markupsafe
+      - py-msgpack
+      - py-pygments
+      - py-pyyaml
+      - py-setuptools
+      - py-virtualenv
+      - py-wheel
+      - python
+      - readline
+      - slurm
+      - tcl
+      - tcsh
+      - util-linux-uuid
+      - util-macros
+      - xcb-proto
+      - xextproto
+      - xtrans
+      - harfbuzz ^cairo~X
+      - pango ^cairo~pdf
+      - '%gcc@7-os'
+      ## ROCm components; we provide a separate metamodule for these
+      - comgr
+      - hip
+      - hip-rocclr
+      - hipblas
+      - hipcub
+      - hipfft
+      - hipfort
+      - hipify-clang
+      - hipsparse
+      - hsa-rocr-dev
+      - hsakmt-roct
+      - llvm-amdgpu
+      - miopen-hip
+      - rccl
+      - rocalution
+      - rocblas
+      - rocfft
+      - rocm-clang-ocl
+      - rocm-cmake
+      - rocm-dbgapi
+      - rocm-device-libs
+      - rocm-gdb
+      - rocm-opencl
+      - rocm-opencl-runtime
+      - rocm-openmp-extras
+      - rocm-smi
+      - rocm-smi-lib
+      - rocminfo
+      - rocprim
+      - rocprofiler-dev
+      - rocrand
+      - rocsolver
+      - rocsparse
+      - rocthrust
+      - roctracer-dev
+      hash_length: 0
+      hierarchy: []
+      projections: {}
+      core_specs: []
+    tcl:
+      hash_length: 3
+      naming_scheme: '{name}/{version}-{compiler.name}-{compiler.version}'
+      blacklist:
+      - slurm
+      - go-bootstrap
+      - openssl
+      all:
+        conflict:
+        - '{name}'
+        environment:
+          set:
+            OLCF_${PACKAGE}_ROOT: ${PREFIX}
+          unset: []
+        filter:
+          environment_blacklist: []
+        load: []
+      verbose: false
+      whitelist: []
+      blacklist_implicits: false
+      projections: {}
+  config:
+    install_tree:
+      root: ${FACSPACK_ENV}/opt
+      projections:
+        all: ${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}
+    module_roots:
+      tcl: ${FACSPACK_ENV_MODULEROOT}/flat
+      lmod: ${FACSPACK_ENV_MODULEROOT}/spack
+    template_dirs:
+    - ${FACSPACK_CONF_HOST}/templates
+    - ${FACSPACK_CONF_COMMON}/spack/templates
+    - $spack/share/spack/templates
+    build_stage:
+    - $tempdir/$user/spack-stage
+    - $spack/var/spack/stage
+    source_cache: ${FACSPACK_SOURCE_CACHE}
+    extensions:
+    - /sw/sources/facspack/share/spack/extensions/spack-olcf
+    misc_cache: ${FACSPACK_ENV}/.mcache
+    verify_ssl: true
+    install_missing_compilers: false
+    checksum: true
+    dirty: false
+    build_language: C
+    build_jobs: 24
+    ccache: false
+    db_lock_timeout: 120
+    package_lock_timeout:
+    shared_linking: rpath
+    allow_sgid: true
+    concretizer: original
+    locks: true
+    suppress_gpg_warnings: false
+    connect_timeout: 10
+    test_stage: ~/.spack/test
+  concretization: separately
+  compilers:
+  - compiler:
+      spec: gcc@7.5.0
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules: []
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@7-os
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules: []
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+        unset: []
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@9.3.0
+      paths:
+        cc: /opt/cray/pe/craype/2.7.6/bin/cc
+        cxx: /opt/cray/pe/craype/2.7.6/bin/CC
+        f77: /opt/cray/pe/craype/2.7.6/bin/ftn
+        fc: /opt/cray/pe/craype/2.7.6/bin/ftn
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-gnu
+      - gcc/9.3.0
+      # - craype-accel-amd-gfx908
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@10.2.0
+      paths:
+        cc: /opt/cray/pe/craype/2.7.8/bin/cc
+        cxx: /opt/cray/pe/craype/2.7.8/bin/CC
+        f77: /opt/cray/pe/craype/2.7.8/bin/ftn
+        fc: /opt/cray/pe/craype/2.7.8/bin/ftn
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-gnu
+      - gcc/10.2.0
+      # - craype-accel-amd-gfx908
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@10.3.0
+      paths:
+        cc: /opt/cray/pe/craype/2.7.8/bin/cc
+        cxx: /opt/cray/pe/craype/2.7.8/bin/CC
+        f77: /opt/cray/pe/craype/2.7.8/bin/ftn
+        fc: /opt/cray/pe/craype/2.7.8/bin/ftn
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-gnu/8.1.0
+      - gcc/10.3.0 ## Override PrgEnv default
+      # - craype-accel-amd-gfx908 ## Base performance option
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: cce@11.0.4
+      paths:
+        cc: /opt/cray/pe/craype/2.7.6/bin/cc
+        cxx: /opt/cray/pe/craype/2.7.6/bin/CC
+        f77: /opt/cray/pe/craype/2.7.6/bin/ftn
+        fc: /opt/cray/pe/craype/2.7.6/bin/ftn
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-cray
+      - cce/11.0.4 ## Override PrgEnv default
+      # - craype-accel-amd-gfx908 ## Base performance option
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: cce@12.0.0
+      paths:
+        cc: /opt/cray/pe/craype/2.7.8/bin/cc
+        cxx: /opt/cray/pe/craype/2.7.8/bin/CC
+        f77: /opt/cray/pe/craype/2.7.8/bin/ftn
+        fc: /opt/cray/pe/craype/2.7.8/bin/ftn
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-cray/8.1.0
+      - cce/12.0.0 ## Override PrgEnv default
+      # - craype-accel-amd-gfx908 ## Base performance option
+      environment:
+        append_path:
+          LD_LIBRARY_PATH: '/opt/cray/pe/gcc-libs'
+      extra_rpaths: 
+        - /opt/cray/pe/gcc-libs
+        - /opt/cray/gcc-libs
+  - compiler:
+      spec: cce@12.0.1
+      paths:
+        cc: /opt/cray/pe/craype/2.7.8/bin/cc
+        cxx: /opt/cray/pe/craype/2.7.8/bin/CC
+        f77: /opt/cray/pe/craype/2.7.8/bin/ftn
+        fc: /opt/cray/pe/craype/2.7.8/bin/ftn
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-cray/8.1.0
+      - cce/12.0.1 ## Override PrgEnv default
+      # - craype-accel-amd-gfx908 ## Base performance option ## breaks cce/mpich
+      # wrt undefined amd hsa libs/amdgpu bc. See logs/{no_accel_module,accel_module_fail}.log
+      environment:
+        append_path:
+          LD_LIBRARY_PATH: '/opt/cray/pe/gcc-libs'
+      extra_rpaths: 
+        - /opt/cray/pe/gcc-libs
+        - /opt/cray/gcc-libs

--- a/OLCF/summit/e4s-21.05.txt
+++ b/OLCF/summit/e4s-21.05.txt
@@ -1,3 +1,4 @@
+$ spack find --format "{name},{version},{compiler},{variants},{arch}"
 adiak,0.2.1,gcc@8.3.1,~ipo+mpi+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
 adiak,0.2.1,gcc@9.1.0,~ipo+mpi+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
 adiak,0.2.1,gcc@9.3.0,~ipo+mpi+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le

--- a/OLCF/summit/e4s-21.05.txt
+++ b/OLCF/summit/e4s-21.05.txt
@@ -1,0 +1,632 @@
+adios@1.13.1%gcc@8.3.1 +blosc+bzip2+fortran+hdf5+infiniband+lz4+mpi+netcdf+shared+sz~szip+zfp+zlib patches=01113e9efb929d71c28bf33cc8b7f215d85195ec700e99cb41164e2f8f830640,8ae17f655248e87cbab1d1ed794e15364a38d2f5f8d971b1086702f72d79bd42,d24b79b795f66e40ddcd331ea4be896ac9c393d6f68f4318616d23928b0694e9 staging=none
+adios2@2.7.1%gcc@7.5.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
+adios2@2.7.1%gcc@8.3.1 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
+adios2@2.7.1%gcc@9.1.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
+adios2@2.7.1%gcc@9.3.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
+adios2@2.7.1%gcc@10.2.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
+adios2@2.7.1%gcc@11.1.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
+adios2@2.7.1%gcc@8.3.1 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png+python+shared+ssc+sst+sz+zfp build_type=Release
+amgx@2.1.0-1%gcc@8.3.1 +cuda~ipo~magma~mkl+mpi+openmp build_type=RelWithDebInfo cuda_arch=70
+aml@0.1.0%gcc@8.3.1
+aml@0.1.0%gcc@9.1.0
+aml@0.1.0%gcc@9.3.0
+aml@0.1.0%gcc@10.2.0
+aml@0.1.0%gcc@11.1.0
+amrex@21.02%gcc@8.3.1 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
+amrex@21.02%gcc@9.1.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
+amrex@21.02%gcc@9.3.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
+amrex@21.02%gcc@10.2.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
+amrex@21.05%gcc@8.3.1 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
+amrex@21.05%gcc@9.1.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
+amrex@21.05%gcc@9.3.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
+amrex@21.05%gcc@10.2.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
+arborx@1.0%gcc@8.3.1 +cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
+arborx@1.0%gcc@9.1.0 +cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
+arborx@1.0%gcc@9.3.0 +cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
+arborx@1.0%gcc@10.2.0 +cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
+argobots@1.1%gcc@11.1.0 ~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none
+ascent@0.7.1%gcc@8.3.1 ~adios~babelflow~cuda~doc~dray+fortran~mfem+mpi+openmp~python+serial+shared+test+vtkh cuda_arch=none
+ascent@0.7.1%gcc@9.1.0 ~adios~babelflow~cuda~doc~dray+fortran~mfem+mpi+openmp~python+serial+shared+test+vtkh cuda_arch=none
+ascent@0.7.1%gcc@9.3.0 ~adios~babelflow~cuda~doc~dray+fortran~mfem+mpi+openmp~python+serial+shared+test+vtkh cuda_arch=none
+axom@0.5.0%gcc@8.3.1 +cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none
+axom@0.5.0%gcc@9.1.0 +cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none
+axom@0.5.0%gcc@9.3.0 +cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none
+axom@0.5.0%gcc@10.2.0 +cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none
+bolt@1.0%gcc@8.3.1 ~ipo build_type=RelWithDebInfo
+bolt@1.0%gcc@9.1.0 ~ipo build_type=RelWithDebInfo
+bolt@1.0%gcc@9.3.0 ~ipo build_type=RelWithDebInfo
+bolt@1.0%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
+bolt@2.0%gcc@8.3.1 ~ipo build_type=RelWithDebInfo
+bolt@2.0%gcc@9.1.0 ~ipo build_type=RelWithDebInfo
+bolt@2.0%gcc@9.3.0 ~ipo build_type=RelWithDebInfo
+bolt@2.0%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
+bolt@2.0%gcc@11.1.0 ~ipo build_type=RelWithDebInfo
+boost@1.62.0%xl@16.1.1-beta103 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden
+boost@1.62.0%xl@16.1.1-10 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden
+boost@1.62.0%xl@16.1.1-beta103 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden
+boost@1.62.0%xl@16.1.1-10 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden
+boost@1.76.0%gcc@7.5.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
+boost@1.76.0%gcc@11.1.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
+boost@1.76.0%gcc@7.5.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
+boost@1.76.0%gcc@8.3.1 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
+boost@1.76.0%gcc@9.1.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
+boost@1.76.0%gcc@9.3.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
+boost@1.76.0%gcc@10.2.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
+boost@1.76.0%gcc@11.1.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
+cabana@0.3.0%gcc@8.3.1 +cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
+cabana@0.3.0%gcc@9.1.0 +cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
+cabana@0.3.0%gcc@9.3.0 +cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
+cabana@0.3.0%gcc@10.2.0 +cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
+caliper@2.4.0%gcc@8.3.1 +adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
+caliper@2.4.0%gcc@9.1.0 +adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
+caliper@2.4.0%gcc@9.3.0 +adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
+caliper@2.4.0%gcc@10.2.0 +adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
+caliper@2.5.0%gcc@8.3.1 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
+caliper@2.5.0%gcc@9.1.0 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
+caliper@2.5.0%gcc@9.3.0 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
+caliper@2.5.0%gcc@10.2.0 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
+ccache@4.3%gcc@8.3.1 ~ipo build_type=RelWithDebInfo
+chai@2.3.0%gcc@8.3.1 ~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+chai@2.3.0%gcc@9.1.0 ~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+chai@2.3.0%gcc@9.3.0 ~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+chai@2.3.0%gcc@10.2.0 ~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+conduit@0.7.2%gcc@9.1.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
+conduit@0.7.2%gcc@9.3.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
+conduit@0.7.2%gcc@10.2.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
+cube@4.6%gcc@8.3.1 +gui
+darshan-runtime@3.2.1%gcc@8.3.1 ~apmpi~apmpi_sync~apxc~cobalt+grouplogs~hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8
+darshan-runtime@3.2.1%gcc@8.3.1 ~apmpi~apmpi_sync~apxc~cobalt+grouplogs+hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8
+darshan-runtime@3.3.0%gcc@8.3.1 ~apmpi~apmpi_sync~apxc~cobalt+grouplogs~hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8
+darshan-runtime@3.3.0%gcc@8.3.1 ~apmpi~apmpi_sync~apxc~cobalt+grouplogs+hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8
+darshan-util@3.3.0%gcc@8.3.1 ~apmpi~apxc~bzip2+shared
+dyninst@10.2.1%gcc@8.3.1 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+dyninst@10.2.1%gcc@9.1.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+dyninst@10.2.1%gcc@9.3.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+dyninst@10.2.1%gcc@10.2.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+dyninst@11.0.0%gcc@8.3.1 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+dyninst@11.0.0%gcc@9.1.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+dyninst@11.0.0%gcc@9.3.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+dyninst@11.0.0%gcc@10.2.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+dyninst@11.0.0%gcc@11.1.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
+emacs@27.2%gcc@8.3.1 ~X~native~tls toolkit=gtk
+faodel@1.1906.1%gcc@8.3.1 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
+faodel@1.1906.1%gcc@9.1.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
+faodel@1.1906.1%gcc@9.3.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
+faodel@1.1906.1%gcc@10.2.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
+fftw@3.3.9%gcc@7.5.0 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%gcc@9.1.0 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%gcc@9.3.0 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%gcc@10.2.0 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%gcc@11.1.0 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%nvhpc@20.9 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%nvhpc@21.2 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%nvhpc@21.3 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%nvhpc@21.5 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%nvhpc@21.7 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%xl@16.1.1-beta103 +mpi+openmp~pfft_patches precision=double,float,long_double
+fftw@3.3.9%xl@16.1.1-10 +mpi+openmp~pfft_patches precision=double,float,long_double
+flecsi@1.4%gcc@8.3.1 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
+flecsi@1.4%gcc@9.1.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
+flecsi@1.4%gcc@9.3.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
+flecsi@1.4%gcc@10.2.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
+flecsi@1.4%gcc@11.1.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
+flit@2.1.0%gcc@8.3.1
+flit@2.1.0%gcc@9.1.0
+flit@2.1.0%gcc@9.3.0
+flit@2.1.0%gcc@10.2.0
+flit@2.1.0%gcc@11.1.0
+gasnet@2020.3.0%gcc@8.3.1 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
+gasnet@2020.3.0%gcc@9.1.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
+gasnet@2020.3.0%gcc@9.3.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
+gasnet@2020.3.0%gcc@10.2.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
+gasnet@2020.3.0%gcc@11.1.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
+gdb@10.2%gcc@8.3.1 ~gold~ld~lto+python~quad~source-highlight~tui+xz patches=0b73f4c573768130ab59fa218cfc352d1db9678423ce787012e46e589154745c
+gdrcopy@2.2%gcc@8.3.1
+ginkgo@1.3.0%gcc@8.3.1 ~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none
+ginkgo@1.3.0%gcc@9.1.0 ~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none
+ginkgo@1.3.0%gcc@9.3.0 ~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none
+ginkgo@1.3.0%gcc@10.2.0 ~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none
+git-lfs@2.11.0%gcc@8.3.1
+globalarrays@5.7%gcc@8.3.1 ~scalapack armci=mpi-ts
+globalarrays@5.7%gcc@9.1.0 ~scalapack armci=mpi-ts
+globalarrays@5.7%gcc@9.3.0 ~scalapack armci=mpi-ts
+globalarrays@5.8%gcc@8.3.1 ~scalapack armci=mpi-ts
+globalarrays@5.8%gcc@9.1.0 ~scalapack armci=mpi-ts
+globalarrays@5.8%gcc@9.3.0 ~scalapack armci=mpi-ts
+globalarrays@5.8%nvhpc@20.9 ~scalapack armci=mpi-ts
+globalarrays@5.8%nvhpc@21.2 ~scalapack armci=mpi-ts
+globalarrays@5.8%nvhpc@21.3 ~scalapack armci=mpi-ts
+globalarrays@5.8%nvhpc@21.5 ~scalapack armci=mpi-ts
+globalarrays@5.8%nvhpc@21.7 ~scalapack armci=mpi-ts
+globalarrays@5.8%pgi@20.1 ~scalapack armci=mpi-ts
+globalarrays@5.8%pgi@20.4 ~scalapack armci=mpi-ts
+gmp@6.2.1%gcc@11.1.0
+gnupg@2.2.19%gcc@8.3.1
+gnuplot@5.0.1%gcc@8.3.1 ~X+cairo+gd+libcerf~pbm~qt~wx patches=ad89f23815fd925889ae78009ba22e6f9e4b12fea389280040cef519deafb052
+gnuplot@5.2.8%gcc@8.3.1 ~X+cairo+gd+libcerf~pbm~qt~wx patches=ad89f23815fd925889ae78009ba22e6f9e4b12fea389280040cef519deafb052
+go@1.16.4%gcc@8.3.1
+googletest@1.11.0%gcc@8.3.1 ~gmock~ipo+pthreads+shared build_type=RelWithDebInfo
+gotcha@1.0.3%gcc@8.3.1 ~ipo~test build_type=RelWithDebInfo
+gotcha@1.0.3%gcc@9.1.0 ~ipo~test build_type=RelWithDebInfo
+gotcha@1.0.3%gcc@9.3.0 ~ipo~test build_type=RelWithDebInfo
+gotcha@1.0.3%gcc@10.2.0 ~ipo~test build_type=RelWithDebInfo
+gotcha@1.0.3%gcc@11.1.0 ~ipo~test build_type=RelWithDebInfo
+gromacs@2020.2%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only~mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
+gromacs@2020.2%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only+mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
+gromacs@2020.4%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only~mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
+gromacs@2020.4%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only+mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
+gromacs@2021.2%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only~mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
+gromacs@2021.2%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only+mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
+gsl@2.6%gcc@8.3.1 ~external-cblas
+hdf5@1.10.6%gcc@8.3.1 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.6%gcc@9.1.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.6%gcc@9.3.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.6%gcc@10.2.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%gcc@7.5.0 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%gcc@9.1.0 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%gcc@9.3.0 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%gcc@10.2.0 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%gcc@11.1.0 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%nvhpc@20.9 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%nvhpc@21.2 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%nvhpc@21.3 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%nvhpc@21.5 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%nvhpc@21.7 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%pgi@20.1 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%pgi@20.4 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%xl@16.1.1-beta103 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%xl@16.1.1-10 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%gcc@7.5.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%gcc@11.1.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%nvhpc@20.9 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%nvhpc@21.2 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%nvhpc@21.3 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%nvhpc@21.5 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%nvhpc@21.7 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%pgi@20.1 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%pgi@20.4 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+hdf5@1.10.7%xl@16.1.1-10 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
+heffte@2.0.0%gcc@8.3.1 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
+heffte@2.0.0%gcc@9.1.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
+heffte@2.0.0%gcc@9.3.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
+heffte@2.0.0%gcc@10.2.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
+hpctoolkit@2020.08.03%gcc@10.2.0 ~all-static~cray+cuda+mpi~papi~rocm patches=0ef29bcf8372658b07bb01742b35eaa40a5db2127b716cffc311e2d00a9db5d9
+hpctoolkit@2020.08.03%gcc@8.3.1 ~all-static~cray+cuda+mpi~papi~rocm
+hpctoolkit@2020.08.03%gcc@9.1.0 ~all-static~cray+cuda+mpi~papi~rocm
+hpctoolkit@2020.08.03%gcc@9.3.0 ~all-static~cray+cuda+mpi~papi~rocm
+hpctoolkit@2021.03.01%gcc@8.3.1 ~all-static~cray+cuda+mpi~papi~rocm
+hpctoolkit@2021.03.01%gcc@9.1.0 ~all-static~cray+cuda+mpi~papi~rocm
+hpctoolkit@2021.03.01%gcc@9.3.0 ~all-static~cray+cuda+mpi~papi~rocm
+hpctoolkit@2021.03.01%gcc@10.2.0 ~all-static~cray+cuda+mpi~papi~rocm
+hpcviewer@2021.03%gcc@8.3.1
+hpx@1.5.1%gcc@8.3.1 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.5.1%gcc@9.1.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.5.1%gcc@9.3.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.5.1%gcc@10.2.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.6.0%gcc@8.3.1 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=14 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.6.0%gcc@8.3.1 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.6.0%gcc@8.3.1 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.6.0%gcc@9.1.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.6.0%gcc@9.3.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+hpx@1.6.0%gcc@10.2.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
+htop@3.0.2%gcc@8.3.1 +unicode
+hypre@2.20.0%gcc@7.5.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%gcc@8.3.1 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%gcc@9.1.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%gcc@9.3.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%gcc@10.2.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%gcc@11.1.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%nvhpc@20.9 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%nvhpc@21.2 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%nvhpc@21.3 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%nvhpc@21.5 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%nvhpc@21.7 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%pgi@20.1 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%pgi@20.4 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%xl@16.1.1-beta103 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+hypre@2.20.0%xl@16.1.1-10 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
+imagemagick@7.0.8-7%gcc@8.3.1
+julia@1.6.1%gcc@8.3.1 +cxx~mkl
+kokkos@3.2.00%gcc@8.3.1 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
+kokkos@3.2.00%gcc@9.1.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
+kokkos@3.2.00%gcc@9.3.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
+kokkos@3.2.00%gcc@10.2.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
+kokkos@3.4.00%gcc@8.3.1 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
+kokkos@3.4.00%gcc@9.1.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
+kokkos@3.4.00%gcc@9.3.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
+kokkos@3.4.00%gcc@10.2.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
+kokkos-kernels@3.2.00%gcc@8.3.1 ~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
+kokkos-kernels@3.2.00%gcc@9.1.0 ~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
+kokkos-kernels@3.2.00%gcc@9.3.0 ~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
+kokkos-kernels@3.2.00%gcc@10.2.0 ~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
+legion@20.03.0%gcc@8.3.1 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+legion@20.03.0%gcc@9.1.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+legion@20.03.0%gcc@9.3.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+legion@20.03.0%gcc@10.2.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+legion@21.03.0%gcc@8.3.1 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+legion@21.03.0%gcc@9.1.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+legion@21.03.0%gcc@9.3.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+legion@21.03.0%gcc@10.2.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
+libevent@2.1.8%gcc@8.3.1 +openssl
+libfabric@1.12.1%gcc@8.3.1 ~kdreg fabrics=rxm,sockets,tcp,udp,verbs
+libquo@1.3.1%gcc@8.3.1
+libquo@1.3.1%gcc@9.1.0
+libquo@1.3.1%gcc@9.3.0
+libquo@1.3.1%gcc@10.2.0
+libquo@1.3.1%gcc@11.1.0
+libzmq@4.3.3%gcc@8.3.1 ~drafts+libsodium
+magma@2.5.3%gcc@8.3.1 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+magma@2.5.4%gcc@8.3.1 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+magma@2.5.4%gcc@9.1.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+magma@2.5.4%gcc@9.3.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+magma@2.5.4%gcc@10.2.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+magma@2.6.1%nvhpc@21.7 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=9fbcf5ad5b7f9713c6ecfe3887d043d393c368e1fa29e2a2ece77e71f64b641d
+magma@2.6.1%gcc@8.3.1 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+magma@2.6.1%gcc@9.1.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+magma@2.6.1%gcc@9.3.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+magma@2.6.1%gcc@10.2.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+makedepend@1.0.5%gcc@8.3.1
+mercurial@5.8%gcc@8.3.1
+mercury@1.0.1%gcc@8.3.1 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo patches=34fc95b3599c74a8cece6e873cfdc8bc0afe2dc0deabb6e2d11ea2a93f0cebf5
+mercury@1.0.1%gcc@9.1.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo patches=34fc95b3599c74a8cece6e873cfdc8bc0afe2dc0deabb6e2d11ea2a93f0cebf5
+mercury@1.0.1%gcc@9.3.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo patches=34fc95b3599c74a8cece6e873cfdc8bc0afe2dc0deabb6e2d11ea2a93f0cebf5
+mercury@2.0.0%gcc@8.3.1 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.0%gcc@9.1.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.0%gcc@9.3.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.0%gcc@10.2.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.1%gcc@8.3.1 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.1%gcc@9.1.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.1%gcc@9.3.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.1%gcc@10.2.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mercury@2.0.1%gcc@11.1.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
+mpifileutils@0.10.1%gcc@8.3.1 ~experimental~gpfs~lustre+xattr
+mpifileutils@0.10.1%gcc@9.1.0 ~experimental~gpfs~lustre+xattr
+mpifileutils@0.10.1%gcc@9.3.0 ~experimental~gpfs~lustre+xattr
+mpifileutils@0.10.1%gcc@10.2.0 ~experimental~gpfs~lustre+xattr
+mpifileutils@0.11%gcc@8.3.1 ~experimental~gpfs~lustre+xattr
+mpifileutils@0.11%gcc@9.1.0 ~experimental~gpfs~lustre+xattr
+mpifileutils@0.11%gcc@9.3.0 ~experimental~gpfs~lustre+xattr
+mpifileutils@0.11%gcc@10.2.0 ~experimental~gpfs~lustre+xattr
+mpifileutils@0.11%gcc@11.1.0 ~experimental~gpfs~lustre+xattr
+mpip@3.5%gcc@7.5.0 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
+mpip@3.5%gcc@8.3.1 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
+mpip@3.5%gcc@9.1.0 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
+mpip@3.5%gcc@9.3.0 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
+mpip@3.5%gcc@10.2.0 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
+mpip@3.5%gcc@11.1.0 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
+nano@4.9%gcc@8.3.1
+nco@4.9.3%gcc@8.3.1 ~doc~mpi~mpi-deps
+nco@4.9.3%gcc@8.3.1 ~doc~mpi+mpi-deps
+nco@4.9.3%gcc@9.1.0 ~doc~mpi+mpi-deps
+nco@4.9.3%gcc@9.3.0 ~doc~mpi+mpi-deps
+netcdf-c@4.8.0%gcc@7.5.0 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
+netcdf-c@4.8.0%gcc@11.1.0 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
+netcdf-c@4.8.0%nvhpc@20.9 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
+netcdf-c@4.8.0%nvhpc@21.2 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
+netcdf-c@4.8.0%nvhpc@21.3 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
+netcdf-c@4.8.0%nvhpc@21.5 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
+netcdf-c@4.8.0%nvhpc@21.7 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
+netcdf-c@4.8.0%pgi@20.1 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
+netcdf-c@4.8.0%pgi@20.4 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
+netcdf-c@4.8.0%xl@16.1.1-10 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
+netcdf-cxx4@4.3.1%gcc@7.5.0 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%gcc@8.3.1 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%gcc@9.1.0 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%gcc@9.3.0 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%gcc@10.2.0 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%gcc@11.1.0 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%nvhpc@20.9 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%nvhpc@21.2 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%nvhpc@21.3 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%nvhpc@21.5 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%nvhpc@21.7 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%pgi@20.1 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%pgi@20.4 ~doxygen+pic+shared+static
+netcdf-cxx4@4.3.1%xl@16.1.1-10 ~doxygen+pic+shared+static
+netcdf-fortran@4.4.5%gcc@7.5.0 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%gcc@8.3.1 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%gcc@9.1.0 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%gcc@9.3.0 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%gcc@10.2.0 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%gcc@11.1.0 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%nvhpc@20.9 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%nvhpc@21.2 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%nvhpc@21.3 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%nvhpc@21.5 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%nvhpc@21.7 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%pgi@20.1 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%pgi@20.4 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netcdf-fortran@4.4.5%xl@16.1.1-10 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
+netlib-lapack@3.8.0%xl@16.1.1-beta103 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo patches=0046d24487c0b7cbc84527fc36300d4e970cb4191b44e8b1619523fae15137f1,5c79286f3d08a0b0f1f3acba2a92ee698647716ba8c6c0ae20c9cc2713e6f139,ad3d41fe9ff94b7661e09fceaf2b2e4b8c83510c1465c016e161541b4429b5ee
+netlib-lapack@3.8.0%xl@16.1.1-10 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo patches=0046d24487c0b7cbc84527fc36300d4e970cb4191b44e8b1619523fae15137f1,5c79286f3d08a0b0f1f3acba2a92ee698647716ba8c6c0ae20c9cc2713e6f139,ad3d41fe9ff94b7661e09fceaf2b2e4b8c83510c1465c016e161541b4429b5ee
+netlib-lapack@3.9.1%gcc@7.5.0 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
+netlib-lapack@3.9.1%gcc@11.1.0 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
+netlib-lapack@3.9.1%nvhpc@20.9 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
+netlib-lapack@3.9.1%nvhpc@21.2 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
+netlib-lapack@3.9.1%nvhpc@21.3 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
+netlib-lapack@3.9.1%nvhpc@21.5 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
+netlib-lapack@3.9.1%nvhpc@21.7 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
+netlib-lapack@3.9.1%pgi@20.1 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
+netlib-lapack@3.9.1%pgi@20.4 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
+netlib-scalapack@2.1.0%gcc@7.5.0 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
+netlib-scalapack@2.1.0%gcc@9.3.0 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
+netlib-scalapack@2.1.0%gcc@11.1.0 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
+netlib-scalapack@2.1.0%pgi@20.4 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
+netlib-scalapack@2.1.0%xl@16.1.1-beta103 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
+netlib-scalapack@2.1.0%xl@16.1.1-10 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
+ninja@1.10.1%gcc@9.1.0
+ninja@1.10.1%gcc@9.3.0
+ninja@1.10.1%gcc@10.2.0
+ninja@1.10.2%gcc@11.1.0
+omega-h@9.32.5%gcc@8.3.1 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
+omega-h@9.32.5%gcc@9.1.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
+omega-h@9.32.5%gcc@9.3.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
+omega-h@9.32.5%gcc@10.2.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
+openblas@0.3.15%gcc@9.3.0 ~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=none
+openblas@0.3.15%gcc@9.3.0 ~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=openmp
+openpmd-api@0.12.0%gcc@8.3.1 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.12.0%gcc@9.1.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.12.0%gcc@9.3.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.12.0%gcc@10.2.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.2%gcc@8.3.1 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.2%gcc@9.1.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.2%gcc@9.3.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.2%gcc@10.2.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.4%gcc@8.3.1 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.4%gcc@9.1.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.4%gcc@9.3.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.4%gcc@10.2.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+openpmd-api@0.13.4%gcc@11.1.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
+papi@6.0.0.1%gcc@8.3.1 ~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools
+papi@6.0.0.1%gcc@8.3.1 +cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools
+papyrus@1.0.0%gcc@8.3.1 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.0%gcc@9.1.0 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.0%gcc@9.3.0 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.0%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.1%gcc@8.3.1 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.1%gcc@9.1.0 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.1%gcc@9.3.0 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.1%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
+papyrus@1.0.1%gcc@11.1.0 ~ipo build_type=RelWithDebInfo
+parallel-io@2.3.0%xl@16.1.1-10 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%gcc@7.5.0 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%gcc@8.3.1 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%gcc@9.1.0 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%gcc@9.3.0 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%gcc@10.2.0 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%gcc@11.1.0 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%nvhpc@20.9 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%nvhpc@21.2 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%nvhpc@21.3 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%nvhpc@21.5 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%nvhpc@21.7 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%pgi@20.1 ~examples~ipo build_type=RelWithDebInfo
+parallel-io@2.4.4%pgi@20.4 ~examples~ipo build_type=RelWithDebInfo
+patchelf@0.12%gcc@8.3.1  patches=a155f233b228f02d7886e304cb13898d93801b52f351e098c2cc0719697ec9d0
+pdt@3.25.1%gcc@8.3.1 ~pic
+pdt@3.25.1%gcc@9.1.0 ~pic
+pdt@3.25.1%gcc@9.3.0 ~pic
+pdt@3.25.1%gcc@10.2.0 ~pic
+pdt@3.25.1%gcc@11.1.0 ~pic
+petsc@3.14.0%gcc@8.3.1 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.14.0%gcc@9.1.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.14.0%gcc@9.3.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.14.0%gcc@10.2.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.14.4%gcc@8.3.1 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.14.4%gcc@9.1.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.14.4%gcc@9.3.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.14.4%gcc@10.2.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.15.0%gcc@8.3.1 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.15.0%gcc@9.1.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.15.0%gcc@9.3.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+petsc@3.15.0%gcc@10.2.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
+pgi@20.1%gcc@8-os ~amd~java+managed+mpi+mpigpu~network+nvidia+single
+pgi@20.4%gcc@8-os ~amd~java+managed+mpi+mpigpu~network+nvidia+single
+plasma@20.9.20%gcc@8.3.1 ~ipo~lua+shared build_type=RelWithDebInfo
+plasma@20.9.20%gcc@9.1.0 ~ipo~lua+shared build_type=RelWithDebInfo
+plasma@20.9.20%gcc@9.3.0 ~ipo~lua+shared build_type=RelWithDebInfo
+plasma@20.9.20%gcc@10.2.0 ~ipo~lua+shared build_type=RelWithDebInfo
+plasma@20.9.20%gcc@11.1.0 ~ipo~lua+shared build_type=RelWithDebInfo
+precice@2.2.0%gcc@8.3.1 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
+precice@2.2.0%gcc@9.1.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
+precice@2.2.0%gcc@9.3.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
+precice@2.2.0%gcc@10.2.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
+precice@2.2.1%gcc@8.3.1 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
+precice@2.2.1%gcc@9.1.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
+precice@2.2.1%gcc@9.3.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
+precice@2.2.1%gcc@10.2.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
+pumi@2.2.2%gcc@8.3.1 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.2%gcc@9.1.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.2%gcc@9.3.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.2%gcc@10.2.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.5%gcc@8.3.1 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.5%gcc@9.1.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.5%gcc@9.3.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.5%gcc@10.2.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+pumi@2.2.5%gcc@11.1.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
+python@2.7.15%gcc@8.3.1 +bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=a8c52415a8b03c0e5f28b5d52ae498f7a7e602007db2b9554df28cd5685839b8
+python@3.7.7%gcc@8.3.1 +bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87
+qthreads@1.14%gcc@8.3.1 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.14%gcc@9.1.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.14%gcc@9.3.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.14%gcc@10.2.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.14%gcc@8.3.1 +hwloc~spawn_cache+static scheduler=nemesis stack_size=4096
+qthreads@1.14%gcc@9.1.0 +hwloc~spawn_cache+static scheduler=nemesis stack_size=4096
+qthreads@1.14%gcc@9.3.0 +hwloc~spawn_cache+static scheduler=nemesis stack_size=4096
+qthreads@1.14%gcc@10.2.0 +hwloc~spawn_cache+static scheduler=nemesis stack_size=4096
+qthreads@1.16%gcc@8.3.1 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.16%gcc@9.1.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.16%gcc@9.3.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.16%gcc@10.2.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+qthreads@1.16%gcc@11.1.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
+r@4.0.5%gcc@8.3.1 ~X~external-lapack~memory_profiling~rmath
+raja@0.12.1%gcc@8.3.1 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+raja@0.12.1%gcc@9.1.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+raja@0.12.1%gcc@9.3.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+raja@0.12.1%gcc@10.2.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+raja@0.13.0%gcc@8.3.1 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+raja@0.13.0%gcc@9.1.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+raja@0.13.0%gcc@9.3.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+raja@0.13.0%gcc@10.2.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+rempi@1.1.0%gcc@8.3.1
+rempi@1.1.0%gcc@9.1.0
+rempi@1.1.0%gcc@9.3.0
+scorep@7.0%gcc@8.3.1 +mpi+papi~pdt~shmem~unwind
+screen@4.8.0%gcc@8.3.1  patches=755de623439b654453801dbbb09cce0f3f889a12ad1a060bf57147d5b2b5c295
+slate@2020.10.00%gcc@8.3.1 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+slate@2020.10.00%gcc@9.1.0 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+slate@2020.10.00%gcc@9.3.0 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+slate@2021.05.02%gcc@8.3.1 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+slate@2021.05.02%gcc@9.1.0 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+slate@2021.05.02%gcc@9.3.0 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+slate@2021.05.02%gcc@10.2.0 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+slepc@3.14.0%gcc@8.3.1 +arpack~blopex
+slepc@3.14.0%gcc@9.1.0 +arpack~blopex
+slepc@3.14.0%gcc@9.3.0 +arpack~blopex
+slepc@3.14.0%gcc@10.2.0 +arpack~blopex
+slepc@3.15.0%gcc@8.3.1 +arpack~blopex
+slepc@3.15.0%gcc@9.1.0 +arpack~blopex
+slepc@3.15.0%gcc@9.3.0 +arpack~blopex
+slepc@3.15.0%gcc@10.2.0 +arpack~blopex
+spectral@20210514%gcc@8.3.1 ~debug~examples~ipo~titan build_type=RelWithDebInfo prologue_dir=/sw/summit/spectral/usr/local
+spectrum-mpi@10.4.0.3-20210112%clang@10.0.1-0
+spectrum-mpi@10.4.0.3-20210112%clang@12.0.0-0
+spectrum-mpi@10.4.0.3-20210112%gcc@7.5.0
+spectrum-mpi@10.4.0.3-20210112%gcc@8.3.1
+spectrum-mpi@10.4.0.3-20210112%gcc@9.1.0
+spectrum-mpi@10.4.0.3-20210112%gcc@9.3.0
+spectrum-mpi@10.4.0.3-20210112%gcc@10.2.0
+spectrum-mpi@10.4.0.3-20210112%gcc@11.1.0
+spectrum-mpi@10.4.0.3-20210112%nvhpc@20.9
+spectrum-mpi@10.4.0.3-20210112%nvhpc@21.2
+spectrum-mpi@10.4.0.3-20210112%nvhpc@21.3
+spectrum-mpi@10.4.0.3-20210112%nvhpc@21.5
+spectrum-mpi@10.4.0.3-20210112%nvhpc@21.7
+spectrum-mpi@10.4.0.3-20210112%pgi@20.1
+spectrum-mpi@10.4.0.3-20210112%pgi@20.4
+spectrum-mpi@10.4.0.3-20210112%xl@16.1.1-10
+stc@0.8.3%gcc@8.3.1
+stc@0.8.3%gcc@9.1.0
+stc@0.8.3%gcc@9.3.0
+stc@0.8.3%gcc@10.2.0
+stc@0.9.0%gcc@8.3.1
+stc@0.9.0%gcc@9.1.0
+stc@0.9.0%gcc@9.3.0
+stc@0.9.0%gcc@10.2.0
+stc@0.9.0%gcc@11.1.0
+strumpack@5.0.0%gcc@8.3.1 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+strumpack@5.0.0%gcc@9.1.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+strumpack@5.0.0%gcc@9.3.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+strumpack@5.0.0%gcc@10.2.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+strumpack@5.1.1%gcc@8.3.1 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+strumpack@5.1.1%gcc@9.1.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+strumpack@5.1.1%gcc@9.3.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+strumpack@5.1.1%gcc@10.2.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
+subversion@1.14.0%gcc@8.3.1 ~perl+serf
+sundials@5.4.0%gcc@8.3.1 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double
+sundials@5.4.0%gcc@9.1.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double
+sundials@5.4.0%gcc@9.3.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double
+sundials@5.4.0%gcc@10.2.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double
+sundials@5.7.0%gcc@8.3.1 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double
+sundials@5.7.0%gcc@9.1.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double
+sundials@5.7.0%gcc@9.3.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double
+sundials@5.7.0%gcc@10.2.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double
+superlu@5.2.1%gcc@8.3.1 +pic
+superlu@5.2.1%gcc@9.1.0 +pic
+superlu@5.2.1%gcc@9.3.0 +pic
+superlu@5.2.1%gcc@10.2.0 +pic
+superlu@5.2.1%gcc@11.1.0 +pic
+superlu-dist@6.3.1%gcc@8.3.1 ~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none
+superlu-dist@6.3.1%gcc@9.1.0 ~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none
+superlu-dist@6.3.1%gcc@9.3.0 ~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none
+superlu-dist@6.3.1%gcc@10.2.0 ~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none
+swig@4.0.2%gcc@8.3.1
+swig@4.0.2%gcc@9.1.0
+swig@4.0.2%gcc@9.3.0
+swig@4.0.2%gcc@10.2.0
+swig@4.0.2-fortran%gcc@8.3.1
+swig@4.0.2-fortran%gcc@9.1.0
+swig@4.0.2-fortran%gcc@9.3.0
+swig@4.0.2-fortran%gcc@10.2.0
+swig@4.0.2-fortran%gcc@11.1.0
+sz@2.1.10%gcc@8.3.1 ~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo
+sz@2.1.10%gcc@9.1.0 ~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo
+sz@2.1.10%gcc@9.3.0 ~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo
+sz@2.1.10%gcc@10.2.0 ~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo
+tasmanian@7.3%gcc@8.3.1 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
+tasmanian@7.3%gcc@9.1.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
+tasmanian@7.3%gcc@9.3.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
+tasmanian@7.3%gcc@10.2.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
+tasmanian@7.5%gcc@8.3.1 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
+tasmanian@7.5%gcc@9.1.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
+tasmanian@7.5%gcc@9.3.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
+tasmanian@7.5%gcc@10.2.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
+tau@2.29.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.29.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tau@2.30.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
+tmux@3.1b%gcc@8.3.1
+trilinos@13.0.0%gcc@8.3.1 ~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long
+trilinos@13.0.0%gcc@9.1.0 ~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long
+trilinos@13.0.0%gcc@9.3.0 ~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long
+trilinos@13.0.0%gcc@10.2.0 ~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long
+umap@2.1.0%gcc@8.3.1 ~ipo~logging~tests build_type=RelWithDebInfo
+umap@2.1.0%gcc@9.1.0 ~ipo~logging~tests build_type=RelWithDebInfo
+umap@2.1.0%gcc@9.3.0 ~ipo~logging~tests build_type=RelWithDebInfo
+umap@2.1.0%gcc@10.2.0 ~ipo~logging~tests build_type=RelWithDebInfo
+umap@2.1.0%gcc@11.1.0 ~ipo~logging~tests build_type=RelWithDebInfo
+umpire@4.0.1%gcc@8.3.1 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none
+umpire@4.0.1%gcc@9.1.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none
+umpire@4.0.1%gcc@9.3.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none
+umpire@4.0.1%gcc@10.2.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none
+umpire@4.1.2%gcc@8.3.1 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none
+umpire@4.1.2%gcc@9.1.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none
+umpire@4.1.2%gcc@9.3.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none
+umpire@4.1.2%gcc@10.2.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none
+unifyfs@0.9.2%gcc@8.3.1 +auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313
+unifyfs@0.9.2%gcc@9.1.0 +auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313
+unifyfs@0.9.2%gcc@9.3.0 +auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313
+unifyfs@0.9.2%gcc@10.2.0 +auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313
+upcxx@2020.3.0%gcc@8.3.1 +cuda~mpi cross=none
+upcxx@2020.3.0%gcc@9.1.0 +cuda~mpi cross=none
+upcxx@2020.3.0%gcc@9.3.0 +cuda~mpi cross=none
+upcxx@2020.3.0%gcc@10.2.0 +cuda~mpi cross=none
+upcxx@2020.10.0%gcc@8.3.1 +cuda~mpi cross=none
+upcxx@2020.10.0%gcc@9.1.0 +cuda~mpi cross=none
+upcxx@2020.10.0%gcc@9.3.0 +cuda~mpi cross=none
+upcxx@2020.10.0%gcc@10.2.0 +cuda~mpi cross=none
+upcxx@2021.3.0%gcc@8.3.1 +cuda~mpi cross=none
+upcxx@2021.3.0%gcc@9.1.0 +cuda~mpi cross=none
+upcxx@2021.3.0%gcc@9.3.0 +cuda~mpi cross=none
+upcxx@2021.3.0%gcc@10.2.0 +cuda~mpi cross=none
+valgrind@3.17.0%gcc@8.3.1 ~boost~mpi+only64bit~ubsan
+valgrind@3.17.0%gcc@8.3.1 +boost+mpi+only64bit~ubsan
+vim@8.2.2541%gcc@8.3.1 ~big~cscope~gui~huge~lua~normal~perl~python~ruby~small~tiny~x

--- a/OLCF/summit/e4s-21.05.txt
+++ b/OLCF/summit/e4s-21.05.txt
@@ -1,632 +1,1510 @@
-adios@1.13.1%gcc@8.3.1 +blosc+bzip2+fortran+hdf5+infiniband+lz4+mpi+netcdf+shared+sz~szip+zfp+zlib patches=01113e9efb929d71c28bf33cc8b7f215d85195ec700e99cb41164e2f8f830640,8ae17f655248e87cbab1d1ed794e15364a38d2f5f8d971b1086702f72d79bd42,d24b79b795f66e40ddcd331ea4be896ac9c393d6f68f4318616d23928b0694e9 staging=none
-adios2@2.7.1%gcc@7.5.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
-adios2@2.7.1%gcc@8.3.1 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
-adios2@2.7.1%gcc@9.1.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
-adios2@2.7.1%gcc@9.3.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
-adios2@2.7.1%gcc@10.2.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
-adios2@2.7.1%gcc@11.1.0 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release
-adios2@2.7.1%gcc@8.3.1 +blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png+python+shared+ssc+sst+sz+zfp build_type=Release
-amgx@2.1.0-1%gcc@8.3.1 +cuda~ipo~magma~mkl+mpi+openmp build_type=RelWithDebInfo cuda_arch=70
-aml@0.1.0%gcc@8.3.1
-aml@0.1.0%gcc@9.1.0
-aml@0.1.0%gcc@9.3.0
-aml@0.1.0%gcc@10.2.0
-aml@0.1.0%gcc@11.1.0
-amrex@21.02%gcc@8.3.1 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
-amrex@21.02%gcc@9.1.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
-amrex@21.02%gcc@9.3.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
-amrex@21.02%gcc@10.2.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
-amrex@21.05%gcc@8.3.1 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
-amrex@21.05%gcc@9.1.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
-amrex@21.05%gcc@9.3.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
-amrex@21.05%gcc@10.2.0 ~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double
-arborx@1.0%gcc@8.3.1 +cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
-arborx@1.0%gcc@9.1.0 +cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
-arborx@1.0%gcc@9.3.0 +cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
-arborx@1.0%gcc@10.2.0 +cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo
-argobots@1.1%gcc@11.1.0 ~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none
-ascent@0.7.1%gcc@8.3.1 ~adios~babelflow~cuda~doc~dray+fortran~mfem+mpi+openmp~python+serial+shared+test+vtkh cuda_arch=none
-ascent@0.7.1%gcc@9.1.0 ~adios~babelflow~cuda~doc~dray+fortran~mfem+mpi+openmp~python+serial+shared+test+vtkh cuda_arch=none
-ascent@0.7.1%gcc@9.3.0 ~adios~babelflow~cuda~doc~dray+fortran~mfem+mpi+openmp~python+serial+shared+test+vtkh cuda_arch=none
-axom@0.5.0%gcc@8.3.1 +cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none
-axom@0.5.0%gcc@9.1.0 +cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none
-axom@0.5.0%gcc@9.3.0 +cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none
-axom@0.5.0%gcc@10.2.0 +cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none
-bolt@1.0%gcc@8.3.1 ~ipo build_type=RelWithDebInfo
-bolt@1.0%gcc@9.1.0 ~ipo build_type=RelWithDebInfo
-bolt@1.0%gcc@9.3.0 ~ipo build_type=RelWithDebInfo
-bolt@1.0%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
-bolt@2.0%gcc@8.3.1 ~ipo build_type=RelWithDebInfo
-bolt@2.0%gcc@9.1.0 ~ipo build_type=RelWithDebInfo
-bolt@2.0%gcc@9.3.0 ~ipo build_type=RelWithDebInfo
-bolt@2.0%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
-bolt@2.0%gcc@11.1.0 ~ipo build_type=RelWithDebInfo
-boost@1.62.0%xl@16.1.1-beta103 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden
-boost@1.62.0%xl@16.1.1-10 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden
-boost@1.62.0%xl@16.1.1-beta103 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden
-boost@1.62.0%xl@16.1.1-10 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden
-boost@1.76.0%gcc@7.5.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
-boost@1.76.0%gcc@11.1.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
-boost@1.76.0%gcc@7.5.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
-boost@1.76.0%gcc@8.3.1 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
-boost@1.76.0%gcc@9.1.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
-boost@1.76.0%gcc@9.3.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
-boost@1.76.0%gcc@10.2.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
-boost@1.76.0%gcc@11.1.0 +atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden
-cabana@0.3.0%gcc@8.3.1 +cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
-cabana@0.3.0%gcc@9.1.0 +cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
-cabana@0.3.0%gcc@9.3.0 +cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
-cabana@0.3.0%gcc@10.2.0 +cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo
-caliper@2.4.0%gcc@8.3.1 +adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
-caliper@2.4.0%gcc@9.1.0 +adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
-caliper@2.4.0%gcc@9.3.0 +adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
-caliper@2.4.0%gcc@10.2.0 +adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
-caliper@2.5.0%gcc@8.3.1 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
-caliper@2.5.0%gcc@9.1.0 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
-caliper@2.5.0%gcc@9.3.0 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
-caliper@2.5.0%gcc@10.2.0 +adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none
-ccache@4.3%gcc@8.3.1 ~ipo build_type=RelWithDebInfo
-chai@2.3.0%gcc@8.3.1 ~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-chai@2.3.0%gcc@9.1.0 ~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-chai@2.3.0%gcc@9.3.0 ~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-chai@2.3.0%gcc@10.2.0 ~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-conduit@0.7.2%gcc@9.1.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
-conduit@0.7.2%gcc@9.3.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
-conduit@0.7.2%gcc@10.2.0 ~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo
-cube@4.6%gcc@8.3.1 +gui
-darshan-runtime@3.2.1%gcc@8.3.1 ~apmpi~apmpi_sync~apxc~cobalt+grouplogs~hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8
-darshan-runtime@3.2.1%gcc@8.3.1 ~apmpi~apmpi_sync~apxc~cobalt+grouplogs+hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8
-darshan-runtime@3.3.0%gcc@8.3.1 ~apmpi~apmpi_sync~apxc~cobalt+grouplogs~hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8
-darshan-runtime@3.3.0%gcc@8.3.1 ~apmpi~apmpi_sync~apxc~cobalt+grouplogs+hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8
-darshan-util@3.3.0%gcc@8.3.1 ~apmpi~apxc~bzip2+shared
-dyninst@10.2.1%gcc@8.3.1 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-dyninst@10.2.1%gcc@9.1.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-dyninst@10.2.1%gcc@9.3.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-dyninst@10.2.1%gcc@10.2.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-dyninst@11.0.0%gcc@8.3.1 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-dyninst@11.0.0%gcc@9.1.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-dyninst@11.0.0%gcc@9.3.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-dyninst@11.0.0%gcc@10.2.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-dyninst@11.0.0%gcc@11.1.0 ~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo
-emacs@27.2%gcc@8.3.1 ~X~native~tls toolkit=gtk
-faodel@1.1906.1%gcc@8.3.1 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
-faodel@1.1906.1%gcc@9.1.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
-faodel@1.1906.1%gcc@9.3.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
-faodel@1.1906.1%gcc@10.2.0 ~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68
-fftw@3.3.9%gcc@7.5.0 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%gcc@9.1.0 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%gcc@9.3.0 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%gcc@10.2.0 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%gcc@11.1.0 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%nvhpc@20.9 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%nvhpc@21.2 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%nvhpc@21.3 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%nvhpc@21.5 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%nvhpc@21.7 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%xl@16.1.1-beta103 +mpi+openmp~pfft_patches precision=double,float,long_double
-fftw@3.3.9%xl@16.1.1-10 +mpi+openmp~pfft_patches precision=double,float,long_double
-flecsi@1.4%gcc@8.3.1 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
-flecsi@1.4%gcc@9.1.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
-flecsi@1.4%gcc@9.3.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
-flecsi@1.4%gcc@10.2.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
-flecsi@1.4%gcc@11.1.0 ~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release
-flit@2.1.0%gcc@8.3.1
-flit@2.1.0%gcc@9.1.0
-flit@2.1.0%gcc@9.3.0
-flit@2.1.0%gcc@10.2.0
-flit@2.1.0%gcc@11.1.0
-gasnet@2020.3.0%gcc@8.3.1 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
-gasnet@2020.3.0%gcc@9.1.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
-gasnet@2020.3.0%gcc@9.3.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
-gasnet@2020.3.0%gcc@10.2.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
-gasnet@2020.3.0%gcc@11.1.0 ~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB
-gdb@10.2%gcc@8.3.1 ~gold~ld~lto+python~quad~source-highlight~tui+xz patches=0b73f4c573768130ab59fa218cfc352d1db9678423ce787012e46e589154745c
-gdrcopy@2.2%gcc@8.3.1
-ginkgo@1.3.0%gcc@8.3.1 ~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none
-ginkgo@1.3.0%gcc@9.1.0 ~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none
-ginkgo@1.3.0%gcc@9.3.0 ~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none
-ginkgo@1.3.0%gcc@10.2.0 ~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none
-git-lfs@2.11.0%gcc@8.3.1
-globalarrays@5.7%gcc@8.3.1 ~scalapack armci=mpi-ts
-globalarrays@5.7%gcc@9.1.0 ~scalapack armci=mpi-ts
-globalarrays@5.7%gcc@9.3.0 ~scalapack armci=mpi-ts
-globalarrays@5.8%gcc@8.3.1 ~scalapack armci=mpi-ts
-globalarrays@5.8%gcc@9.1.0 ~scalapack armci=mpi-ts
-globalarrays@5.8%gcc@9.3.0 ~scalapack armci=mpi-ts
-globalarrays@5.8%nvhpc@20.9 ~scalapack armci=mpi-ts
-globalarrays@5.8%nvhpc@21.2 ~scalapack armci=mpi-ts
-globalarrays@5.8%nvhpc@21.3 ~scalapack armci=mpi-ts
-globalarrays@5.8%nvhpc@21.5 ~scalapack armci=mpi-ts
-globalarrays@5.8%nvhpc@21.7 ~scalapack armci=mpi-ts
-globalarrays@5.8%pgi@20.1 ~scalapack armci=mpi-ts
-globalarrays@5.8%pgi@20.4 ~scalapack armci=mpi-ts
-gmp@6.2.1%gcc@11.1.0
-gnupg@2.2.19%gcc@8.3.1
-gnuplot@5.0.1%gcc@8.3.1 ~X+cairo+gd+libcerf~pbm~qt~wx patches=ad89f23815fd925889ae78009ba22e6f9e4b12fea389280040cef519deafb052
-gnuplot@5.2.8%gcc@8.3.1 ~X+cairo+gd+libcerf~pbm~qt~wx patches=ad89f23815fd925889ae78009ba22e6f9e4b12fea389280040cef519deafb052
-go@1.16.4%gcc@8.3.1
-googletest@1.11.0%gcc@8.3.1 ~gmock~ipo+pthreads+shared build_type=RelWithDebInfo
-gotcha@1.0.3%gcc@8.3.1 ~ipo~test build_type=RelWithDebInfo
-gotcha@1.0.3%gcc@9.1.0 ~ipo~test build_type=RelWithDebInfo
-gotcha@1.0.3%gcc@9.3.0 ~ipo~test build_type=RelWithDebInfo
-gotcha@1.0.3%gcc@10.2.0 ~ipo~test build_type=RelWithDebInfo
-gotcha@1.0.3%gcc@11.1.0 ~ipo~test build_type=RelWithDebInfo
-gromacs@2020.2%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only~mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
-gromacs@2020.2%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only+mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
-gromacs@2020.4%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only~mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
-gromacs@2020.4%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only+mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
-gromacs@2021.2%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only~mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
-gromacs@2021.2%gcc@8.3.1 ~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only+mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo
-gsl@2.6%gcc@8.3.1 ~external-cblas
-hdf5@1.10.6%gcc@8.3.1 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.6%gcc@9.1.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.6%gcc@9.3.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.6%gcc@10.2.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%gcc@7.5.0 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%gcc@9.1.0 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%gcc@9.3.0 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%gcc@10.2.0 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%gcc@11.1.0 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%nvhpc@20.9 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%nvhpc@21.2 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%nvhpc@21.3 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%nvhpc@21.5 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%nvhpc@21.7 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%pgi@20.1 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%pgi@20.4 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%xl@16.1.1-beta103 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%xl@16.1.1-10 +cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%gcc@7.5.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%gcc@11.1.0 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%nvhpc@20.9 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%nvhpc@21.2 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%nvhpc@21.3 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%nvhpc@21.5 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%nvhpc@21.7 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%pgi@20.1 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%pgi@20.4 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-hdf5@1.10.7%xl@16.1.1-10 +cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none
-heffte@2.0.0%gcc@8.3.1 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
-heffte@2.0.0%gcc@9.1.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
-heffte@2.0.0%gcc@9.3.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
-heffte@2.0.0%gcc@10.2.0 ~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c
-hpctoolkit@2020.08.03%gcc@10.2.0 ~all-static~cray+cuda+mpi~papi~rocm patches=0ef29bcf8372658b07bb01742b35eaa40a5db2127b716cffc311e2d00a9db5d9
-hpctoolkit@2020.08.03%gcc@8.3.1 ~all-static~cray+cuda+mpi~papi~rocm
-hpctoolkit@2020.08.03%gcc@9.1.0 ~all-static~cray+cuda+mpi~papi~rocm
-hpctoolkit@2020.08.03%gcc@9.3.0 ~all-static~cray+cuda+mpi~papi~rocm
-hpctoolkit@2021.03.01%gcc@8.3.1 ~all-static~cray+cuda+mpi~papi~rocm
-hpctoolkit@2021.03.01%gcc@9.1.0 ~all-static~cray+cuda+mpi~papi~rocm
-hpctoolkit@2021.03.01%gcc@9.3.0 ~all-static~cray+cuda+mpi~papi~rocm
-hpctoolkit@2021.03.01%gcc@10.2.0 ~all-static~cray+cuda+mpi~papi~rocm
-hpcviewer@2021.03%gcc@8.3.1
-hpx@1.5.1%gcc@8.3.1 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.5.1%gcc@9.1.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.5.1%gcc@9.3.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.5.1%gcc@10.2.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.6.0%gcc@8.3.1 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=14 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.6.0%gcc@8.3.1 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.6.0%gcc@8.3.1 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.6.0%gcc@9.1.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.6.0%gcc@9.3.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-hpx@1.6.0%gcc@10.2.0 ~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp
-htop@3.0.2%gcc@8.3.1 +unicode
-hypre@2.20.0%gcc@7.5.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%gcc@8.3.1 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%gcc@9.1.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%gcc@9.3.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%gcc@10.2.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%gcc@11.1.0 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%nvhpc@20.9 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%nvhpc@21.2 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%nvhpc@21.3 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%nvhpc@21.5 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%nvhpc@21.7 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%pgi@20.1 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%pgi@20.4 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%xl@16.1.1-beta103 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-hypre@2.20.0%xl@16.1.1-10 ~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059
-imagemagick@7.0.8-7%gcc@8.3.1
-julia@1.6.1%gcc@8.3.1 +cxx~mkl
-kokkos@3.2.00%gcc@8.3.1 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
-kokkos@3.2.00%gcc@9.1.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
-kokkos@3.2.00%gcc@9.3.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
-kokkos@3.2.00%gcc@10.2.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
-kokkos@3.4.00%gcc@8.3.1 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
-kokkos@3.4.00%gcc@9.1.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
-kokkos@3.4.00%gcc@9.3.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
-kokkos@3.4.00%gcc@10.2.0 ~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14
-kokkos-kernels@3.2.00%gcc@8.3.1 ~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
-kokkos-kernels@3.2.00%gcc@9.1.0 ~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
-kokkos-kernels@3.2.00%gcc@9.3.0 ~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
-kokkos-kernels@3.2.00%gcc@10.2.0 ~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double
-legion@20.03.0%gcc@8.3.1 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-legion@20.03.0%gcc@9.1.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-legion@20.03.0%gcc@9.3.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-legion@20.03.0%gcc@10.2.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-legion@21.03.0%gcc@8.3.1 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-legion@21.03.0%gcc@9.1.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-legion@21.03.0%gcc@9.3.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-legion@21.03.0%gcc@10.2.0 ~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning
-libevent@2.1.8%gcc@8.3.1 +openssl
-libfabric@1.12.1%gcc@8.3.1 ~kdreg fabrics=rxm,sockets,tcp,udp,verbs
-libquo@1.3.1%gcc@8.3.1
-libquo@1.3.1%gcc@9.1.0
-libquo@1.3.1%gcc@9.3.0
-libquo@1.3.1%gcc@10.2.0
-libquo@1.3.1%gcc@11.1.0
-libzmq@4.3.3%gcc@8.3.1 ~drafts+libsodium
-magma@2.5.3%gcc@8.3.1 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-magma@2.5.4%gcc@8.3.1 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-magma@2.5.4%gcc@9.1.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-magma@2.5.4%gcc@9.3.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-magma@2.5.4%gcc@10.2.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-magma@2.6.1%nvhpc@21.7 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=9fbcf5ad5b7f9713c6ecfe3887d043d393c368e1fa29e2a2ece77e71f64b641d
-magma@2.6.1%gcc@8.3.1 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-magma@2.6.1%gcc@9.1.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-magma@2.6.1%gcc@9.3.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-magma@2.6.1%gcc@10.2.0 +cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-makedepend@1.0.5%gcc@8.3.1
-mercurial@5.8%gcc@8.3.1
-mercury@1.0.1%gcc@8.3.1 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo patches=34fc95b3599c74a8cece6e873cfdc8bc0afe2dc0deabb6e2d11ea2a93f0cebf5
-mercury@1.0.1%gcc@9.1.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo patches=34fc95b3599c74a8cece6e873cfdc8bc0afe2dc0deabb6e2d11ea2a93f0cebf5
-mercury@1.0.1%gcc@9.3.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo patches=34fc95b3599c74a8cece6e873cfdc8bc0afe2dc0deabb6e2d11ea2a93f0cebf5
-mercury@2.0.0%gcc@8.3.1 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.0%gcc@9.1.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.0%gcc@9.3.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.0%gcc@10.2.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.1%gcc@8.3.1 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.1%gcc@9.1.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.1%gcc@9.3.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.1%gcc@10.2.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mercury@2.0.1%gcc@11.1.0 ~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo
-mpifileutils@0.10.1%gcc@8.3.1 ~experimental~gpfs~lustre+xattr
-mpifileutils@0.10.1%gcc@9.1.0 ~experimental~gpfs~lustre+xattr
-mpifileutils@0.10.1%gcc@9.3.0 ~experimental~gpfs~lustre+xattr
-mpifileutils@0.10.1%gcc@10.2.0 ~experimental~gpfs~lustre+xattr
-mpifileutils@0.11%gcc@8.3.1 ~experimental~gpfs~lustre+xattr
-mpifileutils@0.11%gcc@9.1.0 ~experimental~gpfs~lustre+xattr
-mpifileutils@0.11%gcc@9.3.0 ~experimental~gpfs~lustre+xattr
-mpifileutils@0.11%gcc@10.2.0 ~experimental~gpfs~lustre+xattr
-mpifileutils@0.11%gcc@11.1.0 ~experimental~gpfs~lustre+xattr
-mpip@3.5%gcc@7.5.0 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
-mpip@3.5%gcc@8.3.1 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
-mpip@3.5%gcc@9.1.0 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
-mpip@3.5%gcc@9.3.0 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
-mpip@3.5%gcc@10.2.0 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
-mpip@3.5%gcc@11.1.0 ~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8
-nano@4.9%gcc@8.3.1
-nco@4.9.3%gcc@8.3.1 ~doc~mpi~mpi-deps
-nco@4.9.3%gcc@8.3.1 ~doc~mpi+mpi-deps
-nco@4.9.3%gcc@9.1.0 ~doc~mpi+mpi-deps
-nco@4.9.3%gcc@9.3.0 ~doc~mpi+mpi-deps
-netcdf-c@4.8.0%gcc@7.5.0 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
-netcdf-c@4.8.0%gcc@11.1.0 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
-netcdf-c@4.8.0%nvhpc@20.9 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
-netcdf-c@4.8.0%nvhpc@21.2 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
-netcdf-c@4.8.0%nvhpc@21.3 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
-netcdf-c@4.8.0%nvhpc@21.5 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
-netcdf-c@4.8.0%nvhpc@21.7 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
-netcdf-c@4.8.0%pgi@20.1 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
-netcdf-c@4.8.0%pgi@20.4 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
-netcdf-c@4.8.0%xl@16.1.1-10 ~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared
-netcdf-cxx4@4.3.1%gcc@7.5.0 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%gcc@8.3.1 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%gcc@9.1.0 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%gcc@9.3.0 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%gcc@10.2.0 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%gcc@11.1.0 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%nvhpc@20.9 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%nvhpc@21.2 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%nvhpc@21.3 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%nvhpc@21.5 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%nvhpc@21.7 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%pgi@20.1 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%pgi@20.4 ~doxygen+pic+shared+static
-netcdf-cxx4@4.3.1%xl@16.1.1-10 ~doxygen+pic+shared+static
-netcdf-fortran@4.4.5%gcc@7.5.0 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%gcc@8.3.1 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%gcc@9.1.0 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%gcc@9.3.0 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%gcc@10.2.0 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%gcc@11.1.0 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%nvhpc@20.9 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%nvhpc@21.2 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%nvhpc@21.3 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%nvhpc@21.5 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%nvhpc@21.7 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%pgi@20.1 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%pgi@20.4 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netcdf-fortran@4.4.5%xl@16.1.1-10 ~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06
-netlib-lapack@3.8.0%xl@16.1.1-beta103 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo patches=0046d24487c0b7cbc84527fc36300d4e970cb4191b44e8b1619523fae15137f1,5c79286f3d08a0b0f1f3acba2a92ee698647716ba8c6c0ae20c9cc2713e6f139,ad3d41fe9ff94b7661e09fceaf2b2e4b8c83510c1465c016e161541b4429b5ee
-netlib-lapack@3.8.0%xl@16.1.1-10 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo patches=0046d24487c0b7cbc84527fc36300d4e970cb4191b44e8b1619523fae15137f1,5c79286f3d08a0b0f1f3acba2a92ee698647716ba8c6c0ae20c9cc2713e6f139,ad3d41fe9ff94b7661e09fceaf2b2e4b8c83510c1465c016e161541b4429b5ee
-netlib-lapack@3.9.1%gcc@7.5.0 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
-netlib-lapack@3.9.1%gcc@11.1.0 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
-netlib-lapack@3.9.1%nvhpc@20.9 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
-netlib-lapack@3.9.1%nvhpc@21.2 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
-netlib-lapack@3.9.1%nvhpc@21.3 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
-netlib-lapack@3.9.1%nvhpc@21.5 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
-netlib-lapack@3.9.1%nvhpc@21.7 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
-netlib-lapack@3.9.1%pgi@20.1 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
-netlib-lapack@3.9.1%pgi@20.4 ~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo
-netlib-scalapack@2.1.0%gcc@7.5.0 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
-netlib-scalapack@2.1.0%gcc@9.3.0 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
-netlib-scalapack@2.1.0%gcc@11.1.0 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
-netlib-scalapack@2.1.0%pgi@20.4 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
-netlib-scalapack@2.1.0%xl@16.1.1-beta103 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
-netlib-scalapack@2.1.0%xl@16.1.1-10 ~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2
-ninja@1.10.1%gcc@9.1.0
-ninja@1.10.1%gcc@9.3.0
-ninja@1.10.1%gcc@10.2.0
-ninja@1.10.2%gcc@11.1.0
-omega-h@9.32.5%gcc@8.3.1 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
-omega-h@9.32.5%gcc@9.1.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
-omega-h@9.32.5%gcc@9.3.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
-omega-h@9.32.5%gcc@10.2.0 ~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo
-openblas@0.3.15%gcc@9.3.0 ~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=none
-openblas@0.3.15%gcc@9.3.0 ~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=openmp
-openpmd-api@0.12.0%gcc@8.3.1 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.12.0%gcc@9.1.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.12.0%gcc@9.3.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.12.0%gcc@10.2.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.2%gcc@8.3.1 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.2%gcc@9.1.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.2%gcc@9.3.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.2%gcc@10.2.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.4%gcc@8.3.1 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.4%gcc@9.1.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.4%gcc@9.3.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.4%gcc@10.2.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-openpmd-api@0.13.4%gcc@11.1.0 ~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo
-papi@6.0.0.1%gcc@8.3.1 ~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools
-papi@6.0.0.1%gcc@8.3.1 +cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools
-papyrus@1.0.0%gcc@8.3.1 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.0%gcc@9.1.0 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.0%gcc@9.3.0 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.0%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.1%gcc@8.3.1 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.1%gcc@9.1.0 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.1%gcc@9.3.0 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.1%gcc@10.2.0 ~ipo build_type=RelWithDebInfo
-papyrus@1.0.1%gcc@11.1.0 ~ipo build_type=RelWithDebInfo
-parallel-io@2.3.0%xl@16.1.1-10 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%gcc@7.5.0 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%gcc@8.3.1 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%gcc@9.1.0 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%gcc@9.3.0 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%gcc@10.2.0 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%gcc@11.1.0 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%nvhpc@20.9 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%nvhpc@21.2 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%nvhpc@21.3 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%nvhpc@21.5 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%nvhpc@21.7 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%pgi@20.1 ~examples~ipo build_type=RelWithDebInfo
-parallel-io@2.4.4%pgi@20.4 ~examples~ipo build_type=RelWithDebInfo
-patchelf@0.12%gcc@8.3.1  patches=a155f233b228f02d7886e304cb13898d93801b52f351e098c2cc0719697ec9d0
-pdt@3.25.1%gcc@8.3.1 ~pic
-pdt@3.25.1%gcc@9.1.0 ~pic
-pdt@3.25.1%gcc@9.3.0 ~pic
-pdt@3.25.1%gcc@10.2.0 ~pic
-pdt@3.25.1%gcc@11.1.0 ~pic
-petsc@3.14.0%gcc@8.3.1 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.14.0%gcc@9.1.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.14.0%gcc@9.3.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.14.0%gcc@10.2.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.14.4%gcc@8.3.1 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.14.4%gcc@9.1.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.14.4%gcc@9.3.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.14.4%gcc@10.2.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.15.0%gcc@8.3.1 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.15.0%gcc@9.1.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.15.0%gcc@9.3.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-petsc@3.15.0%gcc@10.2.0 ~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C
-pgi@20.1%gcc@8-os ~amd~java+managed+mpi+mpigpu~network+nvidia+single
-pgi@20.4%gcc@8-os ~amd~java+managed+mpi+mpigpu~network+nvidia+single
-plasma@20.9.20%gcc@8.3.1 ~ipo~lua+shared build_type=RelWithDebInfo
-plasma@20.9.20%gcc@9.1.0 ~ipo~lua+shared build_type=RelWithDebInfo
-plasma@20.9.20%gcc@9.3.0 ~ipo~lua+shared build_type=RelWithDebInfo
-plasma@20.9.20%gcc@10.2.0 ~ipo~lua+shared build_type=RelWithDebInfo
-plasma@20.9.20%gcc@11.1.0 ~ipo~lua+shared build_type=RelWithDebInfo
-precice@2.2.0%gcc@8.3.1 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
-precice@2.2.0%gcc@9.1.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
-precice@2.2.0%gcc@9.3.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
-precice@2.2.0%gcc@10.2.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
-precice@2.2.1%gcc@8.3.1 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
-precice@2.2.1%gcc@9.1.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
-precice@2.2.1%gcc@9.3.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
-precice@2.2.1%gcc@10.2.0 ~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo
-pumi@2.2.2%gcc@8.3.1 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.2%gcc@9.1.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.2%gcc@9.3.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.2%gcc@10.2.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.5%gcc@8.3.1 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.5%gcc@9.1.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.5%gcc@9.3.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.5%gcc@10.2.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-pumi@2.2.5%gcc@11.1.0 ~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none
-python@2.7.15%gcc@8.3.1 +bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=a8c52415a8b03c0e5f28b5d52ae498f7a7e602007db2b9554df28cd5685839b8
-python@3.7.7%gcc@8.3.1 +bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87
-qthreads@1.14%gcc@8.3.1 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.14%gcc@9.1.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.14%gcc@9.3.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.14%gcc@10.2.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.14%gcc@8.3.1 +hwloc~spawn_cache+static scheduler=nemesis stack_size=4096
-qthreads@1.14%gcc@9.1.0 +hwloc~spawn_cache+static scheduler=nemesis stack_size=4096
-qthreads@1.14%gcc@9.3.0 +hwloc~spawn_cache+static scheduler=nemesis stack_size=4096
-qthreads@1.14%gcc@10.2.0 +hwloc~spawn_cache+static scheduler=nemesis stack_size=4096
-qthreads@1.16%gcc@8.3.1 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.16%gcc@9.1.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.16%gcc@9.3.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.16%gcc@10.2.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-qthreads@1.16%gcc@11.1.0 +hwloc~spawn_cache+static scheduler=distrib stack_size=4096
-r@4.0.5%gcc@8.3.1 ~X~external-lapack~memory_profiling~rmath
-raja@0.12.1%gcc@8.3.1 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-raja@0.12.1%gcc@9.1.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-raja@0.12.1%gcc@9.3.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-raja@0.12.1%gcc@10.2.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-raja@0.13.0%gcc@8.3.1 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-raja@0.13.0%gcc@9.1.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-raja@0.13.0%gcc@9.3.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-raja@0.13.0%gcc@10.2.0 +cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-rempi@1.1.0%gcc@8.3.1
-rempi@1.1.0%gcc@9.1.0
-rempi@1.1.0%gcc@9.3.0
-scorep@7.0%gcc@8.3.1 +mpi+papi~pdt~shmem~unwind
-screen@4.8.0%gcc@8.3.1  patches=755de623439b654453801dbbb09cce0f3f889a12ad1a060bf57147d5b2b5c295
-slate@2020.10.00%gcc@8.3.1 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-slate@2020.10.00%gcc@9.1.0 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-slate@2020.10.00%gcc@9.3.0 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-slate@2021.05.02%gcc@8.3.1 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-slate@2021.05.02%gcc@9.1.0 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-slate@2021.05.02%gcc@9.3.0 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-slate@2021.05.02%gcc@10.2.0 +cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-slepc@3.14.0%gcc@8.3.1 +arpack~blopex
-slepc@3.14.0%gcc@9.1.0 +arpack~blopex
-slepc@3.14.0%gcc@9.3.0 +arpack~blopex
-slepc@3.14.0%gcc@10.2.0 +arpack~blopex
-slepc@3.15.0%gcc@8.3.1 +arpack~blopex
-slepc@3.15.0%gcc@9.1.0 +arpack~blopex
-slepc@3.15.0%gcc@9.3.0 +arpack~blopex
-slepc@3.15.0%gcc@10.2.0 +arpack~blopex
-spectral@20210514%gcc@8.3.1 ~debug~examples~ipo~titan build_type=RelWithDebInfo prologue_dir=/sw/summit/spectral/usr/local
-spectrum-mpi@10.4.0.3-20210112%clang@10.0.1-0
-spectrum-mpi@10.4.0.3-20210112%clang@12.0.0-0
-spectrum-mpi@10.4.0.3-20210112%gcc@7.5.0
-spectrum-mpi@10.4.0.3-20210112%gcc@8.3.1
-spectrum-mpi@10.4.0.3-20210112%gcc@9.1.0
-spectrum-mpi@10.4.0.3-20210112%gcc@9.3.0
-spectrum-mpi@10.4.0.3-20210112%gcc@10.2.0
-spectrum-mpi@10.4.0.3-20210112%gcc@11.1.0
-spectrum-mpi@10.4.0.3-20210112%nvhpc@20.9
-spectrum-mpi@10.4.0.3-20210112%nvhpc@21.2
-spectrum-mpi@10.4.0.3-20210112%nvhpc@21.3
-spectrum-mpi@10.4.0.3-20210112%nvhpc@21.5
-spectrum-mpi@10.4.0.3-20210112%nvhpc@21.7
-spectrum-mpi@10.4.0.3-20210112%pgi@20.1
-spectrum-mpi@10.4.0.3-20210112%pgi@20.4
-spectrum-mpi@10.4.0.3-20210112%xl@16.1.1-10
-stc@0.8.3%gcc@8.3.1
-stc@0.8.3%gcc@9.1.0
-stc@0.8.3%gcc@9.3.0
-stc@0.8.3%gcc@10.2.0
-stc@0.9.0%gcc@8.3.1
-stc@0.9.0%gcc@9.1.0
-stc@0.9.0%gcc@9.3.0
-stc@0.9.0%gcc@10.2.0
-stc@0.9.0%gcc@11.1.0
-strumpack@5.0.0%gcc@8.3.1 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-strumpack@5.0.0%gcc@9.1.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-strumpack@5.0.0%gcc@9.3.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-strumpack@5.0.0%gcc@10.2.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-strumpack@5.1.1%gcc@8.3.1 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-strumpack@5.1.1%gcc@9.1.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-strumpack@5.1.1%gcc@9.3.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-strumpack@5.1.1%gcc@10.2.0 ~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70
-subversion@1.14.0%gcc@8.3.1 ~perl+serf
-sundials@5.4.0%gcc@8.3.1 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double
-sundials@5.4.0%gcc@9.1.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double
-sundials@5.4.0%gcc@9.3.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double
-sundials@5.4.0%gcc@10.2.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double
-sundials@5.7.0%gcc@8.3.1 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double
-sundials@5.7.0%gcc@9.1.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double
-sundials@5.7.0%gcc@9.3.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double
-sundials@5.7.0%gcc@10.2.0 +ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double
-superlu@5.2.1%gcc@8.3.1 +pic
-superlu@5.2.1%gcc@9.1.0 +pic
-superlu@5.2.1%gcc@9.3.0 +pic
-superlu@5.2.1%gcc@10.2.0 +pic
-superlu@5.2.1%gcc@11.1.0 +pic
-superlu-dist@6.3.1%gcc@8.3.1 ~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none
-superlu-dist@6.3.1%gcc@9.1.0 ~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none
-superlu-dist@6.3.1%gcc@9.3.0 ~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none
-superlu-dist@6.3.1%gcc@10.2.0 ~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none
-swig@4.0.2%gcc@8.3.1
-swig@4.0.2%gcc@9.1.0
-swig@4.0.2%gcc@9.3.0
-swig@4.0.2%gcc@10.2.0
-swig@4.0.2-fortran%gcc@8.3.1
-swig@4.0.2-fortran%gcc@9.1.0
-swig@4.0.2-fortran%gcc@9.3.0
-swig@4.0.2-fortran%gcc@10.2.0
-swig@4.0.2-fortran%gcc@11.1.0
-sz@2.1.10%gcc@8.3.1 ~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo
-sz@2.1.10%gcc@9.1.0 ~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo
-sz@2.1.10%gcc@9.3.0 ~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo
-sz@2.1.10%gcc@10.2.0 ~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo
-tasmanian@7.3%gcc@8.3.1 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
-tasmanian@7.3%gcc@9.1.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
-tasmanian@7.3%gcc@9.3.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
-tasmanian@7.3%gcc@10.2.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
-tasmanian@7.5%gcc@8.3.1 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
-tasmanian@7.5%gcc@9.1.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
-tasmanian@7.5%gcc@9.3.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
-tasmanian@7.5%gcc@10.2.0 ~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none
-tau@2.29.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.29.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@8.3.1 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@9.1.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@9.3.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tau@2.30.1%gcc@10.2.0 ~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64
-tmux@3.1b%gcc@8.3.1
-trilinos@13.0.0%gcc@8.3.1 ~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long
-trilinos@13.0.0%gcc@9.1.0 ~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long
-trilinos@13.0.0%gcc@9.3.0 ~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long
-trilinos@13.0.0%gcc@10.2.0 ~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long
-umap@2.1.0%gcc@8.3.1 ~ipo~logging~tests build_type=RelWithDebInfo
-umap@2.1.0%gcc@9.1.0 ~ipo~logging~tests build_type=RelWithDebInfo
-umap@2.1.0%gcc@9.3.0 ~ipo~logging~tests build_type=RelWithDebInfo
-umap@2.1.0%gcc@10.2.0 ~ipo~logging~tests build_type=RelWithDebInfo
-umap@2.1.0%gcc@11.1.0 ~ipo~logging~tests build_type=RelWithDebInfo
-umpire@4.0.1%gcc@8.3.1 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none
-umpire@4.0.1%gcc@9.1.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none
-umpire@4.0.1%gcc@9.3.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none
-umpire@4.0.1%gcc@10.2.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none
-umpire@4.1.2%gcc@8.3.1 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none
-umpire@4.1.2%gcc@9.1.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none
-umpire@4.1.2%gcc@9.3.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none
-umpire@4.1.2%gcc@10.2.0 +c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none
-unifyfs@0.9.2%gcc@8.3.1 +auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313
-unifyfs@0.9.2%gcc@9.1.0 +auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313
-unifyfs@0.9.2%gcc@9.3.0 +auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313
-unifyfs@0.9.2%gcc@10.2.0 +auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313
-upcxx@2020.3.0%gcc@8.3.1 +cuda~mpi cross=none
-upcxx@2020.3.0%gcc@9.1.0 +cuda~mpi cross=none
-upcxx@2020.3.0%gcc@9.3.0 +cuda~mpi cross=none
-upcxx@2020.3.0%gcc@10.2.0 +cuda~mpi cross=none
-upcxx@2020.10.0%gcc@8.3.1 +cuda~mpi cross=none
-upcxx@2020.10.0%gcc@9.1.0 +cuda~mpi cross=none
-upcxx@2020.10.0%gcc@9.3.0 +cuda~mpi cross=none
-upcxx@2020.10.0%gcc@10.2.0 +cuda~mpi cross=none
-upcxx@2021.3.0%gcc@8.3.1 +cuda~mpi cross=none
-upcxx@2021.3.0%gcc@9.1.0 +cuda~mpi cross=none
-upcxx@2021.3.0%gcc@9.3.0 +cuda~mpi cross=none
-upcxx@2021.3.0%gcc@10.2.0 +cuda~mpi cross=none
-valgrind@3.17.0%gcc@8.3.1 ~boost~mpi+only64bit~ubsan
-valgrind@3.17.0%gcc@8.3.1 +boost+mpi+only64bit~ubsan
-vim@8.2.2541%gcc@8.3.1 ~big~cscope~gui~huge~lua~normal~perl~python~ruby~small~tiny~x
+adiak,0.2.1,gcc@8.3.1,~ipo+mpi+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+adiak,0.2.1,gcc@9.1.0,~ipo+mpi+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+adiak,0.2.1,gcc@9.3.0,~ipo+mpi+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+adiak,0.2.1,gcc@10.2.0,~ipo+mpi+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+adios,1.13.1,gcc@8.3.1,+blosc+bzip2+fortran+hdf5+infiniband+lz4+mpi+netcdf+shared+sz~szip+zfp+zlib patches=01113e9efb929d71c28bf33cc8b7f215d85195ec700e99cb41164e2f8f830640,8ae17f655248e87cbab1d1ed794e15364a38d2f5f8d971b1086702f72d79bd42,d24b79b795f66e40ddcd331ea4be896ac9c393d6f68f4318616d23928b0694e9 staging=none,linux-rhel8-ppc64le
+adios2,2.7.1,gcc@7.5.0,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,linux-rhel8-ppc64le
+adios2,2.7.1,gcc@8.3.1,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,linux-rhel8-ppc64le
+adios2,2.7.1,gcc@9.1.0,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,linux-rhel8-ppc64le
+adios2,2.7.1,gcc@9.3.0,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,linux-rhel8-ppc64le
+adios2,2.7.1,gcc@10.2.0,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,linux-rhel8-ppc64le
+adios2,2.7.1,gcc@11.1.0,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png~python+shared+ssc+sst+sz+zfp build_type=Release,linux-rhel8-ppc64le
+adios2,2.7.1,gcc@8.3.1,+blosc+bzip2~dataman~dataspaces~endian_reverse+fortran~hdf5~ipo+mpi+pic+png+python+shared+ssc+sst+sz+zfp build_type=Release,linux-rhel8-ppc64le
+adlbx,1.0.0,gcc@8.3.1,,linux-rhel8-ppc64le
+adlbx,1.0.0,gcc@9.1.0,,linux-rhel8-ppc64le
+adlbx,1.0.0,gcc@9.3.0,,linux-rhel8-ppc64le
+adlbx,1.0.0,gcc@10.2.0,,linux-rhel8-ppc64le
+adlbx,1.0.0,gcc@11.1.0,,linux-rhel8-ppc64le
+amgx,2.1.0-1,gcc@8.3.1,+cuda~ipo~magma~mkl+mpi+openmp build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+aml,0.1.0,gcc@8.3.1,,linux-rhel8-ppc64le
+aml,0.1.0,gcc@9.1.0,,linux-rhel8-ppc64le
+aml,0.1.0,gcc@9.3.0,,linux-rhel8-ppc64le
+aml,0.1.0,gcc@10.2.0,,linux-rhel8-ppc64le
+aml,0.1.0,gcc@11.1.0,,linux-rhel8-ppc64le
+amrex,21.02,gcc@8.3.1,~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double,linux-rhel8-ppc64le
+amrex,21.02,gcc@9.1.0,~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double,linux-rhel8-ppc64le
+amrex,21.02,gcc@9.3.0,~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double,linux-rhel8-ppc64le
+amrex,21.02,gcc@10.2.0,~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double,linux-rhel8-ppc64le
+amrex,21.05,gcc@8.3.1,~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double,linux-rhel8-ppc64le
+amrex,21.05,gcc@9.1.0,~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double,linux-rhel8-ppc64le
+amrex,21.05,gcc@9.3.0,~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double,linux-rhel8-ppc64le
+amrex,21.05,gcc@10.2.0,~amrdata~cuda~eb~fortran~hdf5~hypre~ipo+linear_solvers+mpi~openmp~particles~petsc~pic~rocm~shared~sundials amdgpu_target=none build_type=RelWithDebInfo cuda_arch=none dimensions=3 precision=double,linux-rhel8-ppc64le
+ant,1.10.7,gcc@8.3.1,,linux-rhel8-ppc64le
+ant,1.10.7,gcc@9.1.0,,linux-rhel8-ppc64le
+ant,1.10.7,gcc@9.3.0,,linux-rhel8-ppc64le
+ant,1.10.7,gcc@10.2.0,,linux-rhel8-ppc64le
+ant,1.10.7,gcc@11.1.0,,linux-rhel8-ppc64le
+antlr,2.7.7,gcc@8.3.1,+cxx~java~python patches=33897ad12ad33878daa0aca55c9a234ec972407eb2b6c03808f6ed020c88b8db,linux-rhel8-ppc64le
+antlr,2.7.7,gcc@9.1.0,+cxx~java~python patches=33897ad12ad33878daa0aca55c9a234ec972407eb2b6c03808f6ed020c88b8db,linux-rhel8-ppc64le
+antlr,2.7.7,gcc@9.3.0,+cxx~java~python patches=33897ad12ad33878daa0aca55c9a234ec972407eb2b6c03808f6ed020c88b8db,linux-rhel8-ppc64le
+apr,1.7.0,gcc@8.3.1, patches=a4128488c546646b4a585c3d49706675b1c016139dd61bdd153fb3151bbcb12c,linux-rhel8-ppc64le
+apr-util,1.6.1,gcc@8.3.1,+crypto~gdbm~odbc~pgsql~sqlite,linux-rhel8-ppc64le
+arborx,1.0,gcc@8.3.1,+cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo,linux-rhel8-ppc64le
+arborx,1.0,gcc@9.1.0,+cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo,linux-rhel8-ppc64le
+arborx,1.0,gcc@9.3.0,+cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo,linux-rhel8-ppc64le
+arborx,1.0,gcc@10.2.0,+cuda~ipo+mpi~openmp~rocm+serial~trilinos build_type=RelWithDebInfo,linux-rhel8-ppc64le
+argobots,1.1,gcc@8.3.1,~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none,linux-rhel8-ppc64le
+argobots,1.1,gcc@9.1.0,~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none,linux-rhel8-ppc64le
+argobots,1.1,gcc@9.3.0,~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none,linux-rhel8-ppc64le
+argobots,1.1,gcc@10.2.0,~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none,linux-rhel8-ppc64le
+argobots,1.1,gcc@11.1.0,~affinity~debug+perf~stackunwind~tool~valgrind stackguard=none,linux-rhel8-ppc64le
+arpack-ng,3.8.0,gcc@8.3.1,+mpi+shared,linux-rhel8-ppc64le
+arpack-ng,3.8.0,gcc@9.1.0,+mpi+shared,linux-rhel8-ppc64le
+arpack-ng,3.8.0,gcc@9.3.0,+mpi+shared,linux-rhel8-ppc64le
+arpack-ng,3.8.0,gcc@10.2.0,+mpi+shared,linux-rhel8-ppc64le
+ascent,0.7.1,gcc@8.3.1,~adios~babelflow~cuda~doc~dray+fortran~mfem+mpi+openmp~python+serial+shared+test+vtkh cuda_arch=none,linux-rhel8-ppc64le
+ascent,0.7.1,gcc@9.1.0,~adios~babelflow~cuda~doc~dray+fortran~mfem+mpi+openmp~python+serial+shared+test+vtkh cuda_arch=none,linux-rhel8-ppc64le
+ascent,0.7.1,gcc@9.3.0,~adios~babelflow~cuda~doc~dray+fortran~mfem+mpi+openmp~python+serial+shared+test+vtkh cuda_arch=none,linux-rhel8-ppc64le
+autoconf,2.69,gcc@7.5.0,,linux-rhel8-ppc64le
+autoconf,2.69,gcc@8-os,,linux-rhel8-ppc64le
+autoconf,2.69,gcc@8.3.1,,linux-rhel8-ppc64le
+autoconf,2.69,gcc@9.1.0,,linux-rhel8-ppc64le
+autoconf,2.69,gcc@9.3.0,,linux-rhel8-ppc64le
+autoconf,2.69,gcc@10.2.0,,linux-rhel8-ppc64le
+autoconf,2.69,gcc@11.1.0,,linux-rhel8-ppc64le
+autoconf-archive,2019.01.06,gcc@8.3.1,,linux-rhel8-ppc64le
+autoconf-archive,2019.01.06,gcc@9.1.0,,linux-rhel8-ppc64le
+autoconf-archive,2019.01.06,gcc@9.3.0,,linux-rhel8-ppc64le
+autoconf-archive,2019.01.06,gcc@10.2.0,,linux-rhel8-ppc64le
+automake,1.16.3,gcc@7.5.0,,linux-rhel8-ppc64le
+automake,1.16.3,gcc@8-os,,linux-rhel8-ppc64le
+automake,1.16.3,gcc@8.3.1,,linux-rhel8-ppc64le
+automake,1.16.3,gcc@9.1.0,,linux-rhel8-ppc64le
+automake,1.16.3,gcc@9.3.0,,linux-rhel8-ppc64le
+automake,1.16.3,gcc@10.2.0,,linux-rhel8-ppc64le
+automake,1.16.3,gcc@11.1.0,,linux-rhel8-ppc64le
+axom,0.5.0,gcc@8.3.1,+cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+axom,0.5.0,gcc@9.1.0,+cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+axom,0.5.0,gcc@9.3.0,+cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+axom,0.5.0,gcc@10.2.0,+cpp14~cuda~debug~devtools+fortran+hdf5~ipo+lua~mfem+mpi+openmp~python+raja~scr+shared+umpire build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+bdftopcf,1.0.5,gcc@8.3.1,,linux-rhel8-ppc64le
+berkeley-db,18.1.40,gcc@7.5.0,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,linux-rhel8-ppc64le
+berkeley-db,18.1.40,gcc@8-os,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,linux-rhel8-ppc64le
+berkeley-db,18.1.40,gcc@8.3.1,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,linux-rhel8-ppc64le
+berkeley-db,18.1.40,gcc@9.1.0,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,linux-rhel8-ppc64le
+berkeley-db,18.1.40,gcc@9.3.0,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,linux-rhel8-ppc64le
+berkeley-db,18.1.40,gcc@10.2.0,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,linux-rhel8-ppc64le
+berkeley-db,18.1.40,gcc@11.1.0,+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522,linux-rhel8-ppc64le
+binutils,2.33.1,gcc@8.3.1,~gas~gold+headers~interwork~ld+libiberty~lto+nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.33.1,gcc@9.1.0,~gas~gold+headers~interwork~ld+libiberty~lto+nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.33.1,gcc@9.3.0,~gas~gold+headers~interwork~ld+libiberty~lto+nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.33.1,gcc@10.2.0,~gas~gold+headers~interwork~ld+libiberty~lto+nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.36.1,gcc@8.3.1,~gas~gold~headers~interwork~ld+libiberty~lto~nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.36.1,gcc@9.1.0,~gas~gold~headers~interwork~ld+libiberty~lto~nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.36.1,gcc@9.3.0,~gas~gold~headers~interwork~ld+libiberty~lto~nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.36.1,gcc@10.2.0,~gas~gold~headers~interwork~ld+libiberty~lto~nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.36.1,gcc@8.3.1,~gas~gold~headers~interwork~ld+libiberty~lto+nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.36.1,gcc@9.1.0,~gas~gold~headers~interwork~ld+libiberty~lto+nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.36.1,gcc@9.3.0,~gas~gold~headers~interwork~ld+libiberty~lto+nls+plugins libs=shared,static,linux-rhel8-ppc64le
+binutils,2.36.1,gcc@10.2.0,~gas~gold~headers~interwork~ld+libiberty~lto+nls+plugins libs=shared,static,linux-rhel8-ppc64le
+bison,3.7.6,gcc@8.3.1,,linux-rhel8-ppc64le
+bison,3.7.6,gcc@9.1.0,,linux-rhel8-ppc64le
+bison,3.7.6,gcc@9.3.0,,linux-rhel8-ppc64le
+bison,3.7.6,gcc@10.2.0,,linux-rhel8-ppc64le
+bison,3.7.6,gcc@11.1.0,,linux-rhel8-ppc64le
+blaspp,2020.10.02,gcc@8.3.1,+cuda~ipo+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+blaspp,2020.10.02,gcc@9.1.0,+cuda~ipo+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+blaspp,2020.10.02,gcc@9.3.0,+cuda~ipo+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+blaspp,2021.04.01,gcc@8.3.1,+cuda~ipo+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+blaspp,2021.04.01,gcc@9.1.0,+cuda~ipo+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+blaspp,2021.04.01,gcc@9.3.0,+cuda~ipo+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+blaspp,2021.04.01,gcc@10.2.0,+cuda~ipo+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+blt,0.3.6,gcc@8.3.1,,linux-rhel8-ppc64le
+blt,0.3.6,gcc@9.1.0,,linux-rhel8-ppc64le
+blt,0.3.6,gcc@9.3.0,,linux-rhel8-ppc64le
+blt,0.3.6,gcc@10.2.0,,linux-rhel8-ppc64le
+bolt,1.0,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+bolt,1.0,gcc@9.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+bolt,1.0,gcc@9.3.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+bolt,1.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+bolt,2.0,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+bolt,2.0,gcc@9.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+bolt,2.0,gcc@9.3.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+bolt,2.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+bolt,2.0,gcc@11.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+boost,1.62.0,xl@16.1.1-beta103,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden,linux-rhel8-ppc64le
+boost,1.62.0,xl@16.1.1-10,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden,linux-rhel8-ppc64le
+boost,1.62.0,xl@16.1.1-beta103,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden,linux-rhel8-ppc64le
+boost,1.62.0,xl@16.1.1-10,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=d1cd178ea5348fafbba797113fc5a92cc822f3606dc2fe65c14cc2275334001b,fb7d84358c36309062fa4aaaa187343eb16871bd95893f0270e0941955c488ab,fd64b4f1e9c136549c7b704bd0014283e1515de8b68e54f0dd0cde758866eb69 visibility=hidden,linux-rhel8-ppc64le
+boost,1.72.0,gcc@8.3.1,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=14 patches=e13cca1cfad7dcce9ed3d4ef989c14e464c4ea00caaf335f762e3677b35cab61 visibility=hidden,linux-rhel8-ppc64le
+boost,1.72.0,gcc@8.3.1,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=17 patches=e13cca1cfad7dcce9ed3d4ef989c14e464c4ea00caaf335f762e3677b35cab61 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@8.3.1,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=17 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@9.1.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=17 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@9.3.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=17 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@10.2.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=17 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@11.1.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=17 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@8.3.1,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=global,linux-rhel8-ppc64le
+boost,1.76.0,gcc@9.1.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=global,linux-rhel8-ppc64le
+boost,1.76.0,gcc@9.3.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=global,linux-rhel8-ppc64le
+boost,1.76.0,gcc@10.2.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=global,linux-rhel8-ppc64le
+boost,1.76.0,gcc@7.5.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@8.3.1,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@9.1.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@9.3.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@10.2.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@11.1.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@7.5.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@8.3.1,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@9.1.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@9.3.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@10.2.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+boost,1.76.0,gcc@11.1.0,+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math+mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden,linux-rhel8-ppc64le
+bzip2,1.0.8,gcc@7.5.0,~debug~pic+shared,linux-rhel8-ppc64le
+bzip2,1.0.8,gcc@8.3.1,~debug~pic+shared,linux-rhel8-ppc64le
+bzip2,1.0.8,gcc@9.1.0,~debug~pic+shared,linux-rhel8-ppc64le
+bzip2,1.0.8,gcc@9.3.0,~debug~pic+shared,linux-rhel8-ppc64le
+bzip2,1.0.8,gcc@10.2.0,~debug~pic+shared,linux-rhel8-ppc64le
+bzip2,1.0.8,gcc@11.1.0,~debug~pic+shared,linux-rhel8-ppc64le
+bzip2,1.0.8,xl@16.1.1-beta103,~debug~pic+shared,linux-rhel8-ppc64le
+bzip2,1.0.8,xl@16.1.1-10,~debug~pic+shared,linux-rhel8-ppc64le
+c-blosc,1.21.0,gcc@7.5.0,+avx2~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+c-blosc,1.21.0,gcc@8.3.1,+avx2~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+c-blosc,1.21.0,gcc@9.1.0,+avx2~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+c-blosc,1.21.0,gcc@9.3.0,+avx2~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+c-blosc,1.21.0,gcc@10.2.0,+avx2~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+c-blosc,1.21.0,gcc@11.1.0,+avx2~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+cabana,0.3.0,gcc@8.3.1,+cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+cabana,0.3.0,gcc@9.1.0,+cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+cabana,0.3.0,gcc@9.3.0,+cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+cabana,0.3.0,gcc@10.2.0,+cuda~ipo+mpi~openmp+serial+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+cairo,1.16.0,gcc@8.3.1,~X~fc+ft~gobject+pdf~png~svg patches=7c4da77767fe9feb03f8051def0832f0c67f99162913275cfa127a88df19cf51,linux-rhel8-ppc64le
+cairo,1.16.0,gcc@8.3.1,~X+fc+ft+gobject+pdf~png~svg patches=7c4da77767fe9feb03f8051def0832f0c67f99162913275cfa127a88df19cf51,linux-rhel8-ppc64le
+cairo,1.16.0,gcc@8.3.1,+X+fc+ft+gobject+pdf~png~svg patches=7c4da77767fe9feb03f8051def0832f0c67f99162913275cfa127a88df19cf51,linux-rhel8-ppc64le
+caliper,2.4.0,gcc@8.3.1,+adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+caliper,2.4.0,gcc@9.1.0,+adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+caliper,2.4.0,gcc@9.3.0,+adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+caliper,2.4.0,gcc@10.2.0,+adiak~cuda~fortran+gotcha~ipo~libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+caliper,2.5.0,gcc@8.3.1,+adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+caliper,2.5.0,gcc@9.1.0,+adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+caliper,2.5.0,gcc@9.3.0,+adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+caliper,2.5.0,gcc@10.2.0,+adiak~cuda~fortran+gotcha~ipo+libdw~libpfm+libunwind+mpi+papi+sampler+shared~sosflow build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+camp,0.1.0,gcc@8.3.1,+cuda~ipo~rocm~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+camp,0.1.0,gcc@9.1.0,+cuda~ipo~rocm~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+camp,0.1.0,gcc@9.3.0,+cuda~ipo~rocm~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+camp,0.1.0,gcc@10.2.0,+cuda~ipo~rocm~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+ccache,4.3,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+chai,2.3.0,gcc@8.3.1,~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+chai,2.3.0,gcc@9.1.0,~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+chai,2.3.0,gcc@9.3.0,~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+chai,2.3.0,gcc@10.2.0,~benchmarks+cuda~enable_pick+examples~ipo~raja~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+cinch,master,gcc@8.3.1,,linux-rhel8-ppc64le
+cinch,master,gcc@9.1.0,,linux-rhel8-ppc64le
+cinch,master,gcc@9.3.0,,linux-rhel8-ppc64le
+cinch,master,gcc@10.2.0,,linux-rhel8-ppc64le
+cinch,master,gcc@11.1.0,,linux-rhel8-ppc64le
+cmake,3.20.2,gcc@7.5.0,~doc+ncurses+openssl+ownlibs~qt build_type=Release,linux-rhel8-ppc64le
+cmake,3.20.2,gcc@8-os,~doc+ncurses+openssl+ownlibs~qt build_type=Release,linux-rhel8-ppc64le
+cmake,3.20.2,gcc@8.3.1,~doc+ncurses+openssl+ownlibs~qt build_type=Release,linux-rhel8-ppc64le
+cmake,3.20.2,gcc@9.1.0,~doc+ncurses+openssl+ownlibs~qt build_type=Release,linux-rhel8-ppc64le
+cmake,3.20.2,gcc@9.3.0,~doc+ncurses+openssl+ownlibs~qt build_type=Release,linux-rhel8-ppc64le
+cmake,3.20.2,gcc@10.2.0,~doc+ncurses+openssl+ownlibs~qt build_type=Release,linux-rhel8-ppc64le
+cmake,3.20.2,gcc@11.1.0,~doc+ncurses+openssl+ownlibs~qt build_type=Release,linux-rhel8-ppc64le
+conduit,0.7.2,gcc@8.3.1,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,linux-rhel8-ppc64le
+conduit,0.7.2,gcc@8.3.1,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,linux-rhel8-ppc64le
+conduit,0.7.2,gcc@9.1.0,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,linux-rhel8-ppc64le
+conduit,0.7.2,gcc@9.1.0,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,linux-rhel8-ppc64le
+conduit,0.7.2,gcc@9.3.0,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,linux-rhel8-ppc64le
+conduit,0.7.2,gcc@9.3.0,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,linux-rhel8-ppc64le
+conduit,0.7.2,gcc@10.2.0,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,linux-rhel8-ppc64le
+conduit,0.7.2,gcc@10.2.0,~adios~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi~python+shared~silo+test~zfp build_type=RelWithDebInfo,linux-rhel8-ppc64le
+cub,1.9.10,gcc@8.3.1,,linux-rhel8-ppc64le
+cub,1.9.10,gcc@9.1.0,,linux-rhel8-ppc64le
+cub,1.9.10,gcc@9.3.0,,linux-rhel8-ppc64le
+cub,1.9.10,gcc@10.2.0,,linux-rhel8-ppc64le
+cube,4.6,gcc@8.3.1,+gui,linux-rhel8-ppc64le
+cubelib,4.6,gcc@8.3.1,,linux-rhel8-ppc64le
+cubew,4.6,gcc@8.3.1,,linux-rhel8-ppc64le
+cuda,10.2.89,gcc@8.3.1,~dev,linux-rhel8-ppc64le
+cuda,11.0.3,gcc@8.3.1,~dev,linux-rhel8-ppc64le
+cuda,11.0.3,gcc@9.1.0,~dev,linux-rhel8-ppc64le
+cuda,11.0.3,gcc@9.3.0,~dev,linux-rhel8-ppc64le
+cuda,11.0.3,nvhpc@21.7,~dev,linux-rhel8-ppc64le
+cuda,11.1.1,gcc@8.3.1,~dev,linux-rhel8-ppc64le
+cuda,11.1.1,gcc@10.2.0,~dev,linux-rhel8-ppc64le
+curl,7.76.1,gcc@8.3.1,~darwinssl~gssapi~libssh~libssh2~nghttp2,linux-rhel8-ppc64le
+curl,7.76.1,gcc@9.1.0,~darwinssl~gssapi~libssh~libssh2~nghttp2,linux-rhel8-ppc64le
+curl,7.76.1,gcc@9.3.0,~darwinssl~gssapi~libssh~libssh2~nghttp2,linux-rhel8-ppc64le
+curl,7.76.1,gcc@10.2.0,~darwinssl~gssapi~libssh~libssh2~nghttp2,linux-rhel8-ppc64le
+darshan-runtime,3.2.1,gcc@8.3.1,~apmpi~apmpi_sync~apxc~cobalt+grouplogs~hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8,linux-rhel8-ppc64le
+darshan-runtime,3.2.1,gcc@8.3.1,~apmpi~apmpi_sync~apxc~cobalt+grouplogs+hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8,linux-rhel8-ppc64le
+darshan-runtime,3.3.0,gcc@8.3.1,~apmpi~apmpi_sync~apxc~cobalt+grouplogs~hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8,linux-rhel8-ppc64le
+darshan-runtime,3.3.0,gcc@8.3.1,~apmpi~apmpi_sync~apxc~cobalt+grouplogs+hdf5+lsf+mpi~pbs~slurm logpath=/gpfs/alpine/darshan/summit patches=efe278f618b00735c814660b980dbedcb397965909e649b81a904b12c48288d8,linux-rhel8-ppc64le
+darshan-util,3.3.0,gcc@8.3.1,~apmpi~apxc~bzip2+shared,linux-rhel8-ppc64le
+dbus,1.12.8,gcc@8.3.1,,linux-rhel8-ppc64le
+diffutils,3.7,gcc@7.5.0,,linux-rhel8-ppc64le
+diffutils,3.7,gcc@8.3.1,,linux-rhel8-ppc64le
+diffutils,3.7,gcc@9.1.0,,linux-rhel8-ppc64le
+diffutils,3.7,gcc@9.3.0,,linux-rhel8-ppc64le
+diffutils,3.7,gcc@10.2.0,,linux-rhel8-ppc64le
+diffutils,3.7,gcc@11.1.0,,linux-rhel8-ppc64le
+diffutils,3.7,xl@16.1.1-beta103,,linux-rhel8-ppc64le
+diffutils,3.7,xl@16.1.1-10,,linux-rhel8-ppc64le
+double-conversion,2.0.1,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dtcmp,1.1.1,gcc@8.3.1,,linux-rhel8-ppc64le
+dtcmp,1.1.1,gcc@9.1.0,,linux-rhel8-ppc64le
+dtcmp,1.1.1,gcc@9.3.0,,linux-rhel8-ppc64le
+dtcmp,1.1.1,gcc@10.2.0,,linux-rhel8-ppc64le
+dtcmp,1.1.1,gcc@11.1.0,,linux-rhel8-ppc64le
+dyninst,10.2.1,gcc@8.3.1,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,10.2.1,gcc@9.1.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,10.2.1,gcc@9.3.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,10.2.1,gcc@10.2.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,11.0.0,gcc@8.3.1,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,11.0.0,gcc@8.3.1,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,11.0.0,gcc@9.1.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,11.0.0,gcc@9.1.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,11.0.0,gcc@9.3.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,11.0.0,gcc@9.3.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,11.0.0,gcc@10.2.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,11.0.0,gcc@10.2.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+dyninst,11.0.0,gcc@11.1.0,~ipo+openmp~stat_dysect~static build_type=RelWithDebInfo,linux-rhel8-ppc64le
+eigen,3.3.9,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+eigen,3.3.9,gcc@9.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+eigen,3.3.9,gcc@9.3.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+eigen,3.3.9,gcc@10.2.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+elfutils,0.182,gcc@8.3.1,~bzip2~debuginfod+nls~xz,linux-rhel8-ppc64le
+elfutils,0.182,gcc@9.1.0,~bzip2~debuginfod+nls~xz,linux-rhel8-ppc64le
+elfutils,0.182,gcc@9.3.0,~bzip2~debuginfod+nls~xz,linux-rhel8-ppc64le
+elfutils,0.182,gcc@10.2.0,~bzip2~debuginfod+nls~xz,linux-rhel8-ppc64le
+elfutils,0.182,gcc@11.1.0,~bzip2~debuginfod+nls~xz,linux-rhel8-ppc64le
+elfutils,0.182,gcc@8.3.1,+bzip2~debuginfod~nls+xz,linux-rhel8-ppc64le
+elfutils,0.182,gcc@9.1.0,+bzip2~debuginfod~nls+xz,linux-rhel8-ppc64le
+elfutils,0.182,gcc@9.3.0,+bzip2~debuginfod~nls+xz,linux-rhel8-ppc64le
+elfutils,0.182,gcc@10.2.0,+bzip2~debuginfod~nls+xz,linux-rhel8-ppc64le
+emacs,27.2,gcc@8.3.1,~X~native~tls toolkit=gtk,linux-rhel8-ppc64le
+exmcutils,0.6.0,gcc@8.3.1,,linux-rhel8-ppc64le
+exmcutils,0.6.0,gcc@9.1.0,,linux-rhel8-ppc64le
+exmcutils,0.6.0,gcc@9.3.0,,linux-rhel8-ppc64le
+exmcutils,0.6.0,gcc@10.2.0,,linux-rhel8-ppc64le
+exmcutils,0.6.0,gcc@11.1.0,,linux-rhel8-ppc64le
+expat,2.3.0,gcc@7.5.0,+libbsd,linux-rhel8-ppc64le
+expat,2.3.0,gcc@8.3.1,+libbsd,linux-rhel8-ppc64le
+expat,2.3.0,gcc@9.1.0,+libbsd,linux-rhel8-ppc64le
+expat,2.3.0,gcc@9.3.0,+libbsd,linux-rhel8-ppc64le
+expat,2.3.0,gcc@10.2.0,+libbsd,linux-rhel8-ppc64le
+expat,2.3.0,gcc@11.1.0,+libbsd,linux-rhel8-ppc64le
+exuberant-ctags,5.8,gcc@8.3.1,,linux-rhel8-ppc64le
+faodel,1.1906.1,gcc@8.3.1,~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68,linux-rhel8-ppc64le
+faodel,1.1906.1,gcc@9.1.0,~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68,linux-rhel8-ppc64le
+faodel,1.1906.1,gcc@9.3.0,~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68,linux-rhel8-ppc64le
+faodel,1.1906.1,gcc@10.2.0,~cereal~hdf5~ipo+mpi+shared~tcmalloc build_type=RelWithDebInfo logging=stdout network=nnti patches=0d8604c48c421da1a28e5c23493a55c367fc39ebdf054f2978b4b6f2108bef91,823eff7668eb4ac2bac4b2b337d9edbeb486d60fc5a98177e9c9b1883159ef68,linux-rhel8-ppc64le
+fftw,3.3.9,gcc@7.5.0,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,gcc@8.3.1,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,gcc@9.1.0,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,gcc@9.3.0,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,gcc@10.2.0,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,gcc@11.1.0,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,nvhpc@20.9,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,nvhpc@21.2,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,nvhpc@21.3,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,nvhpc@21.5,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,nvhpc@21.7,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,xl@16.1.1-beta103,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+fftw,3.3.9,xl@16.1.1-10,+mpi+openmp~pfft_patches precision=double,float,long_double,linux-rhel8-ppc64le
+findutils,4.8.0,gcc@8.3.1,,linux-rhel8-ppc64le
+findutils,4.8.0,gcc@9.1.0,,linux-rhel8-ppc64le
+findutils,4.8.0,gcc@9.3.0,,linux-rhel8-ppc64le
+flecsi,1.4,gcc@8.3.1,~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release,linux-rhel8-ppc64le
+flecsi,1.4,gcc@9.1.0,~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release,linux-rhel8-ppc64le
+flecsi,1.4,gcc@9.3.0,~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release,linux-rhel8-ppc64le
+flecsi,1.4,gcc@10.2.0,~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release,linux-rhel8-ppc64le
+flecsi,1.4,gcc@11.1.0,~caliper+cinch~coverage~debug_backend~doc~doxygen~flecstan~flog~graphviz+hdf5~ipo~minimal+shared~tutorial backend=mpi build_type=Release,linux-rhel8-ppc64le
+flex,2.6.3,gcc@8.3.1,+lex~nls,linux-rhel8-ppc64le
+flex,2.6.3,gcc@9.1.0,+lex~nls,linux-rhel8-ppc64le
+flex,2.6.3,gcc@9.3.0,+lex~nls,linux-rhel8-ppc64le
+flit,2.1.0,gcc@8.3.1,,linux-rhel8-ppc64le
+flit,2.1.0,gcc@9.1.0,,linux-rhel8-ppc64le
+flit,2.1.0,gcc@9.3.0,,linux-rhel8-ppc64le
+flit,2.1.0,gcc@10.2.0,,linux-rhel8-ppc64le
+flit,2.1.0,gcc@11.1.0,,linux-rhel8-ppc64le
+font-util,1.3.2,gcc@8.3.1, fonts=encodings,font-adobe-100dpi,font-adobe-75dpi,font-adobe-utopia-100dpi,font-adobe-utopia-75dpi,font-adobe-utopia-type1,font-alias,font-arabic-misc,font-bh-100dpi,font-bh-75dpi,font-bh-lucidatypewriter-100dpi,font-bh-lucidatypewriter-75dpi,font-bh-type1,font-bitstream-100dpi,font-bitstream-75dpi,font-bitstream-speedo,font-bitstream-type1,font-cronyx-cyrillic,font-cursor-misc,font-daewoo-misc,font-dec-misc,font-ibm-type1,font-isas-misc,font-jis-misc,font-micro-misc,font-misc-cyrillic,font-misc-ethiopic,font-misc-meltho,font-misc-misc,font-mutt-misc,font-schumacher-misc,font-screen-cyrillic,font-sun-misc,font-winitzki-cyrillic,font-xfree86-type1,linux-rhel8-ppc64le
+fontconfig,2.13.93,gcc@8.3.1,,linux-rhel8-ppc64le
+fontsproto,2.1.3,gcc@8.3.1,,linux-rhel8-ppc64le
+freetype,2.10.4,gcc@8.3.1,,linux-rhel8-ppc64le
+gasnet,2020.3.0,gcc@8.3.1,~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB,linux-rhel8-ppc64le
+gasnet,2020.3.0,gcc@9.1.0,~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB,linux-rhel8-ppc64le
+gasnet,2020.3.0,gcc@9.3.0,~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB,linux-rhel8-ppc64le
+gasnet,2020.3.0,gcc@10.2.0,~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB,linux-rhel8-ppc64le
+gasnet,2020.3.0,gcc@11.1.0,~aligned-segments~ibv+mpi+pshm~udp segment-mmap-max=16GB,linux-rhel8-ppc64le
+gawk,5.1.0,gcc@8.3.1,,linux-rhel8-ppc64le
+gdb,10.2,gcc@8.3.1,~gold~ld~lto+python~quad~source-highlight~tui+xz patches=0b73f4c573768130ab59fa218cfc352d1db9678423ce787012e46e589154745c,linux-rhel8-ppc64le
+gdbm,1.19,gcc@7.5.0,,linux-rhel8-ppc64le
+gdbm,1.19,gcc@8-os,,linux-rhel8-ppc64le
+gdbm,1.19,gcc@8.3.1,,linux-rhel8-ppc64le
+gdbm,1.19,gcc@9.1.0,,linux-rhel8-ppc64le
+gdbm,1.19,gcc@9.3.0,,linux-rhel8-ppc64le
+gdbm,1.19,gcc@10.2.0,,linux-rhel8-ppc64le
+gdbm,1.19,gcc@11.1.0,,linux-rhel8-ppc64le
+gdrcopy,2.2,gcc@8.3.1,,linux-rhel8-ppc64le
+gettext,0.21,gcc@7.5.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-rhel8-ppc64le
+gettext,0.21,gcc@8.3.1,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-rhel8-ppc64le
+gettext,0.21,gcc@8.3.1,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-rhel8-ppc64le
+gettext,0.21,gcc@9.1.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-rhel8-ppc64le
+gettext,0.21,gcc@9.1.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-rhel8-ppc64le
+gettext,0.21,gcc@9.3.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-rhel8-ppc64le
+gettext,0.21,gcc@9.3.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-rhel8-ppc64le
+gettext,0.21,gcc@10.2.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-rhel8-ppc64le
+gettext,0.21,gcc@10.2.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-rhel8-ppc64le
+gettext,0.21,gcc@11.1.0,+bzip2+curses+git~libunistring+libxml2+tar+xz,linux-rhel8-ppc64le
+ghostscript,9.54.0,gcc@8.3.1,,linux-rhel8-ppc64le
+ghostscript-fonts,8.11,gcc@8.3.1,,linux-rhel8-ppc64le
+ginkgo,1.3.0,gcc@8.3.1,~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+ginkgo,1.3.0,gcc@9.1.0,~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+ginkgo,1.3.0,gcc@9.3.0,~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+ginkgo,1.3.0,gcc@10.2.0,~cuda~develtools~full_optimizations~hwloc~ipo+openmp~rocm+shared amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+git,2.31.1,gcc@8.3.1,+man+nls+perl~svn~tcltk,linux-rhel8-ppc64le
+git,2.31.1,gcc@9.1.0,+man+nls+perl~svn~tcltk,linux-rhel8-ppc64le
+git,2.31.1,gcc@9.3.0,+man+nls+perl~svn~tcltk,linux-rhel8-ppc64le
+git,2.31.1,gcc@10.2.0,+man+nls+perl~svn~tcltk,linux-rhel8-ppc64le
+git-lfs,2.11.0,gcc@8.3.1,,linux-rhel8-ppc64le
+glib,2.68.2,gcc@8.3.1,~libmount patches=b3fd45063a19c871048aa1f28692293ab8971a871bdcbe65f06f17fdd79db9e2 tracing=none,linux-rhel8-ppc64le
+glm,0.9.9.8,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+glm,0.9.9.8,gcc@9.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+glm,0.9.9.8,gcc@9.3.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+glm,0.9.9.8,gcc@10.2.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+globalarrays,5.7,gcc@8.3.1,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.7,gcc@9.1.0,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.7,gcc@9.3.0,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.8,gcc@8.3.1,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.8,gcc@9.1.0,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.8,gcc@9.3.0,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.8,nvhpc@20.9,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.8,nvhpc@21.2,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.8,nvhpc@21.3,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.8,nvhpc@21.5,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.8,nvhpc@21.7,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.8,pgi@20.1,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+globalarrays,5.8,pgi@20.4,~scalapack armci=mpi-ts,linux-rhel8-ppc64le
+gmake,4.3,gcc@8.3.1,~guile+nls,linux-rhel8-ppc64le
+gmake,4.3,gcc@9.1.0,~guile+nls,linux-rhel8-ppc64le
+gmake,4.3,gcc@9.3.0,~guile+nls,linux-rhel8-ppc64le
+gmake,4.3,gcc@10.2.0,~guile+nls,linux-rhel8-ppc64le
+gmake,4.3,gcc@11.1.0,~guile+nls,linux-rhel8-ppc64le
+gmp,6.2.1,gcc@8.3.1,,linux-rhel8-ppc64le
+gmp,6.2.1,gcc@9.1.0,,linux-rhel8-ppc64le
+gmp,6.2.1,gcc@9.3.0,,linux-rhel8-ppc64le
+gmp,6.2.1,gcc@10.2.0,,linux-rhel8-ppc64le
+gmp,6.2.1,gcc@11.1.0,,linux-rhel8-ppc64le
+gnupg,2.2.19,gcc@8.3.1,,linux-rhel8-ppc64le
+gnuplot,5.0.1,gcc@8.3.1,~X+cairo+gd+libcerf~pbm~qt~wx patches=ad89f23815fd925889ae78009ba22e6f9e4b12fea389280040cef519deafb052,linux-rhel8-ppc64le
+gnuplot,5.2.8,gcc@8.3.1,~X+cairo+gd+libcerf~pbm~qt~wx patches=ad89f23815fd925889ae78009ba22e6f9e4b12fea389280040cef519deafb052,linux-rhel8-ppc64le
+go,1.16.4,gcc@8.3.1,,linux-rhel8-ppc64le
+gobject-introspection,1.56.1,gcc@8.3.1, patches=6f90bb267efa043ed70b900b4b8e2faf9e8133afae311893b01060356ea81bba,7700828b638c85255c87fcc317ea7e9572ff443f65c86648796528885e5b4cea,linux-rhel8-ppc64le
+gobject-introspection,1.56.1,gcc@8.3.1, patches=6f90bb267efa043ed70b900b4b8e2faf9e8133afae311893b01060356ea81bba,7700828b638c85255c87fcc317ea7e9572ff443f65c86648796528885e5b4cea,linux-rhel8-ppc64le
+googletest,1.8.1,gcc@8.3.1,+gmock~ipo+pthreads+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+googletest,1.8.1,gcc@9.1.0,+gmock~ipo+pthreads+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+googletest,1.8.1,gcc@9.3.0,+gmock~ipo+pthreads+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+googletest,1.8.1,gcc@10.2.0,+gmock~ipo+pthreads+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+googletest,1.8.1,gcc@11.1.0,+gmock~ipo+pthreads+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+googletest,1.11.0,gcc@8.3.1,~gmock~ipo+pthreads+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gotcha,1.0.3,gcc@8.3.1,~ipo~test build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gotcha,1.0.3,gcc@9.1.0,~ipo~test build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gotcha,1.0.3,gcc@9.3.0,~ipo~test build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gotcha,1.0.3,gcc@10.2.0,~ipo~test build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gotcha,1.0.3,gcc@11.1.0,~ipo~test build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gperf,3.1,gcc@8.3.1,,linux-rhel8-ppc64le
+gperftools,2.8.1,gcc@8.3.1,,linux-rhel8-ppc64le
+gperftools,2.8.1,gcc@9.1.0,,linux-rhel8-ppc64le
+gperftools,2.8.1,gcc@9.3.0,,linux-rhel8-ppc64le
+gperftools,2.8.1,gcc@10.2.0,,linux-rhel8-ppc64le
+gromacs,2020.2,gcc@8.3.1,~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only~mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gromacs,2020.2,gcc@8.3.1,~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only+mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gromacs,2020.4,gcc@8.3.1,~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only~mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gromacs,2020.4,gcc@8.3.1,~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only+mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gromacs,2021.2,gcc@8.3.1,~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only~mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gromacs,2021.2,gcc@8.3.1,~blas+cuda~cycle_subcounters~double+hwloc~ipo~lapack~mdrun_only+mpi~nosuffix~opencl+openmp~plumed~relaxed_double_precision+shared~sycl build_type=RelWithDebInfo,linux-rhel8-ppc64le
+gsl,2.6,gcc@8.3.1,~external-cblas,linux-rhel8-ppc64le
+gsl,2.6,gcc@9.1.0,~external-cblas,linux-rhel8-ppc64le
+gsl,2.6,gcc@9.3.0,~external-cblas,linux-rhel8-ppc64le
+gtkplus,3.22.30,gcc@8.3.1,~cups~strip buildtype=debugoptimized default_library=shared,linux-rhel8-ppc64le
+harfbuzz,2.6.8,gcc@8.3.1,~graphite2,linux-rhel8-ppc64le
+harfbuzz,2.6.8,gcc@8.3.1,~graphite2,linux-rhel8-ppc64le
+harfbuzz,2.6.8,gcc@8.3.1,~graphite2,linux-rhel8-ppc64le
+hdf5,1.8.22,gcc@8.3.1,~cxx~debug~fortran+hl~java+mpi+pic~shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.8.22,gcc@9.1.0,~cxx~debug~fortran+hl~java+mpi+pic~shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.8.22,gcc@9.3.0,~cxx~debug~fortran+hl~java+mpi+pic~shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.8.22,gcc@10.2.0,~cxx~debug~fortran+hl~java+mpi+pic~shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.8.22,gcc@8.3.1,~cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.8.22,gcc@9.1.0,~cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.8.22,gcc@9.3.0,~cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.8.22,gcc@10.2.0,~cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.6,gcc@8.3.1,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.6,gcc@9.1.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.6,gcc@9.3.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.6,gcc@10.2.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@7.5.0,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@8.3.1,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@9.1.0,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@9.3.0,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@10.2.0,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@11.1.0,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,nvhpc@20.9,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,nvhpc@21.2,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,nvhpc@21.3,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,nvhpc@21.5,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,nvhpc@21.7,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,pgi@20.1,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,pgi@20.4,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,xl@16.1.1-beta103,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,xl@16.1.1-10,+cxx~debug+fortran+hl~java~mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@7.5.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@8.3.1,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@9.1.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@9.3.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@10.2.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,gcc@11.1.0,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,nvhpc@20.9,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,nvhpc@21.2,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,nvhpc@21.3,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,nvhpc@21.5,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,nvhpc@21.7,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,pgi@20.1,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,pgi@20.4,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,xl@16.1.1-beta103,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+hdf5,1.10.7,xl@16.1.1-10,+cxx~debug+fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none,linux-rhel8-ppc64le
+heffte,2.0.0,gcc@8.3.1,~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c,linux-rhel8-ppc64le
+heffte,2.0.0,gcc@9.1.0,~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c,linux-rhel8-ppc64le
+heffte,2.0.0,gcc@9.3.0,~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c,linux-rhel8-ppc64le
+heffte,2.0.0,gcc@10.2.0,~cuda+fftw~fortran~ipo~magma~mkl~python+shared build_type=RelWithDebInfo patches=c520da92eb86d41ba6da8a3ec86995ef07489170e93f59c3a7e8908d6336561c,linux-rhel8-ppc64le
+hpctoolkit,2020.08.03,gcc@10.2.0,~all-static~cray+cuda+mpi~papi~rocm patches=0ef29bcf8372658b07bb01742b35eaa40a5db2127b716cffc311e2d00a9db5d9,linux-rhel8-ppc64le
+hpctoolkit,2020.08.03,gcc@8.3.1,~all-static~cray+cuda+mpi~papi~rocm,linux-rhel8-ppc64le
+hpctoolkit,2020.08.03,gcc@9.1.0,~all-static~cray+cuda+mpi~papi~rocm,linux-rhel8-ppc64le
+hpctoolkit,2020.08.03,gcc@9.3.0,~all-static~cray+cuda+mpi~papi~rocm,linux-rhel8-ppc64le
+hpctoolkit,2021.03.01,gcc@8.3.1,~all-static~cray+cuda+mpi~papi~rocm,linux-rhel8-ppc64le
+hpctoolkit,2021.03.01,gcc@9.1.0,~all-static~cray+cuda+mpi~papi~rocm,linux-rhel8-ppc64le
+hpctoolkit,2021.03.01,gcc@9.3.0,~all-static~cray+cuda+mpi~papi~rocm,linux-rhel8-ppc64le
+hpctoolkit,2021.03.01,gcc@10.2.0,~all-static~cray+cuda+mpi~papi~rocm,linux-rhel8-ppc64le
+hpcviewer,2021.03,gcc@8.3.1,,linux-rhel8-ppc64le
+hpx,1.5.1,gcc@8.3.1,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,linux-rhel8-ppc64le
+hpx,1.5.1,gcc@9.1.0,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,linux-rhel8-ppc64le
+hpx,1.5.1,gcc@9.3.0,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,linux-rhel8-ppc64le
+hpx,1.5.1,gcc@10.2.0,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,linux-rhel8-ppc64le
+hpx,1.6.0,gcc@8.3.1,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=14 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,linux-rhel8-ppc64le
+hpx,1.6.0,gcc@8.3.1,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,linux-rhel8-ppc64le
+hpx,1.6.0,gcc@8.3.1,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,linux-rhel8-ppc64le
+hpx,1.6.0,gcc@9.1.0,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,linux-rhel8-ppc64le
+hpx,1.6.0,gcc@9.3.0,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,linux-rhel8-ppc64le
+hpx,1.6.0,gcc@10.2.0,~async_cuda~async_mpi~cuda~examples~generic_coroutines~ipo~tools build_type=RelWithDebInfo cuda_arch=none cxxstd=17 instrumentation=none malloc=tcmalloc max_cpu_count=64 networking=tcp,linux-rhel8-ppc64le
+htop,3.0.2,gcc@8.3.1,+unicode,linux-rhel8-ppc64le
+hwloc,1.11.13,gcc@8.3.1,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared patches=d1d94a4af93486c88c70b79cd930979f3a2a2b5843708e8c7c1655f18b9fc694,linux-rhel8-ppc64le
+hwloc,1.11.13,gcc@9.1.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared patches=d1d94a4af93486c88c70b79cd930979f3a2a2b5843708e8c7c1655f18b9fc694,linux-rhel8-ppc64le
+hwloc,1.11.13,gcc@9.3.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared patches=d1d94a4af93486c88c70b79cd930979f3a2a2b5843708e8c7c1655f18b9fc694,linux-rhel8-ppc64le
+hwloc,1.11.13,gcc@10.2.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared patches=d1d94a4af93486c88c70b79cd930979f3a2a2b5843708e8c7c1655f18b9fc694,linux-rhel8-ppc64le
+hwloc,2.4.1,gcc@8.3.1,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared,linux-rhel8-ppc64le
+hwloc,2.4.1,gcc@9.1.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared,linux-rhel8-ppc64le
+hwloc,2.4.1,gcc@9.3.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared,linux-rhel8-ppc64le
+hwloc,2.4.1,gcc@10.2.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared,linux-rhel8-ppc64le
+hwloc,2.4.1,gcc@11.1.0,~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared,linux-rhel8-ppc64le
+hypre,2.20.0,gcc@7.5.0,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,gcc@8.3.1,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,gcc@9.1.0,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,gcc@9.3.0,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,gcc@10.2.0,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,gcc@11.1.0,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,nvhpc@20.9,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,nvhpc@21.2,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,nvhpc@21.3,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,nvhpc@21.5,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,nvhpc@21.7,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,pgi@20.1,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,pgi@20.4,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,xl@16.1.1-beta103,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+hypre,2.20.0,xl@16.1.1-10,~complex~cuda~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059,linux-rhel8-ppc64le
+icu4c,66.1,gcc@8.3.1, cxxstd=11,linux-rhel8-ppc64le
+imagemagick,7.0.8-7,gcc@8.3.1,,linux-rhel8-ppc64le
+inputproto,2.3.2,gcc@8.3.1,,linux-rhel8-ppc64le
+intel-tbb,2020.3,gcc@8.3.1,+shared+tm cxxstd=default patches=62ba015ebd1819c45bef47411540b789b493e31ca668c4ff4cb2afcbc306b476,ce1fb16fb932ce86a82ca87cf0431d1a8c83652af9f552b264213b2ff2945d73,d62cb666de4010998c339cde6f41c7623a07e9fc69e498f2e149821c0c2c6dd0,linux-rhel8-ppc64le
+intel-tbb,2020.3,gcc@9.1.0,+shared+tm cxxstd=default patches=62ba015ebd1819c45bef47411540b789b493e31ca668c4ff4cb2afcbc306b476,ce1fb16fb932ce86a82ca87cf0431d1a8c83652af9f552b264213b2ff2945d73,d62cb666de4010998c339cde6f41c7623a07e9fc69e498f2e149821c0c2c6dd0,linux-rhel8-ppc64le
+intel-tbb,2020.3,gcc@9.3.0,+shared+tm cxxstd=default patches=62ba015ebd1819c45bef47411540b789b493e31ca668c4ff4cb2afcbc306b476,ce1fb16fb932ce86a82ca87cf0431d1a8c83652af9f552b264213b2ff2945d73,d62cb666de4010998c339cde6f41c7623a07e9fc69e498f2e149821c0c2c6dd0,linux-rhel8-ppc64le
+intel-tbb,2020.3,gcc@10.2.0,+shared+tm cxxstd=default patches=62ba015ebd1819c45bef47411540b789b493e31ca668c4ff4cb2afcbc306b476,ce1fb16fb932ce86a82ca87cf0431d1a8c83652af9f552b264213b2ff2945d73,d62cb666de4010998c339cde6f41c7623a07e9fc69e498f2e149821c0c2c6dd0,linux-rhel8-ppc64le
+intel-tbb,2020.3,gcc@11.1.0,+shared+tm cxxstd=default patches=62ba015ebd1819c45bef47411540b789b493e31ca668c4ff4cb2afcbc306b476,ce1fb16fb932ce86a82ca87cf0431d1a8c83652af9f552b264213b2ff2945d73,d62cb666de4010998c339cde6f41c7623a07e9fc69e498f2e149821c0c2c6dd0,linux-rhel8-ppc64le
+json-c,0.15,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+json-c,0.15,gcc@9.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+json-c,0.15,gcc@9.3.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+json-c,0.15,gcc@10.2.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+julia,1.6.1,gcc@8.3.1,+cxx~mkl,linux-rhel8-ppc64le
+kbproto,1.0.7,gcc@8.3.1,,linux-rhel8-ppc64le
+kokkos,3.2.00,gcc@8.3.1,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.2.00,gcc@9.1.0,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.2.00,gcc@9.3.0,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.2.00,gcc@10.2.0,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@8.3.1,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@9.1.0,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@9.3.0,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@10.2.0,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@8.3.1,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@9.1.0,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@9.3.0,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@10.2.0,~aggressive_vectorization~compiler_warnings+cuda~cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl+openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@8.3.1,~aggressive_vectorization~compiler_warnings+cuda+cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@9.1.0,~aggressive_vectorization~compiler_warnings+cuda+cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@9.3.0,~aggressive_vectorization~compiler_warnings+cuda+cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos,3.4.00,gcc@10.2.0,~aggressive_vectorization~compiler_warnings+cuda+cuda_lambda~cuda_ldg_intrinsic~cuda_relocatable_device_code~cuda_uvm~debug~debug_bounds_check~debug_dualview_modify_check~deprecated_code~examples~explicit_instantiation~hpx~hpx_async_dispatch~hwloc~ipo~memkind~numactl~openmp~pic+profiling~profiling_load_print~pthread~qthread~rocm+serial+shared~sycl~tests~tuning+wrapper amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 std=14,linux-rhel8-ppc64le
+kokkos-kernels,3.2.00,gcc@8.3.1,~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double,linux-rhel8-ppc64le
+kokkos-kernels,3.2.00,gcc@9.1.0,~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double,linux-rhel8-ppc64le
+kokkos-kernels,3.2.00,gcc@9.3.0,~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double,linux-rhel8-ppc64le
+kokkos-kernels,3.2.00,gcc@10.2.0,~blas~cblas~cublas+cuda~cusparse~ipo~lapack~lapacke~mkl~openmp~pthread~serial~superlu build_type=RelWithDebInfo cuda_arch=70 execspace_cuda=auto execspace_openmp=auto execspace_serial=auto execspace_threads=auto layouts=left memspace_cudaspace=auto memspace_cudauvmspace=auto offsets=int,size_t ordinals=int scalars=double,linux-rhel8-ppc64le
+kokkos-nvcc-wrapper,3.2.00,gcc@8.3.1,+mpi,linux-rhel8-ppc64le
+kokkos-nvcc-wrapper,3.2.00,gcc@9.1.0,+mpi,linux-rhel8-ppc64le
+kokkos-nvcc-wrapper,3.2.00,gcc@9.3.0,+mpi,linux-rhel8-ppc64le
+kokkos-nvcc-wrapper,3.2.00,gcc@10.2.0,+mpi,linux-rhel8-ppc64le
+krb5,1.18.2,gcc@8.3.1,+shared patches=3d75052730690579484e65a5bf0f92f6c3b20d9c43a413862d087774f431d9e9,linux-rhel8-ppc64le
+lapackpp,2020.10.02,gcc@8.3.1,~ipo+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+lapackpp,2020.10.02,gcc@9.1.0,~ipo+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+lapackpp,2020.10.02,gcc@9.3.0,~ipo+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+lapackpp,2021.04.00,gcc@8.3.1,~ipo+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+lapackpp,2021.04.00,gcc@9.1.0,~ipo+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+lapackpp,2021.04.00,gcc@9.3.0,~ipo+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+lapackpp,2021.04.00,gcc@10.2.0,~ipo+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+lcms,2.9,gcc@8.3.1,,linux-rhel8-ppc64le
+legion,20.03.0,gcc@8.3.1,~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,linux-rhel8-ppc64le
+legion,20.03.0,gcc@9.1.0,~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,linux-rhel8-ppc64le
+legion,20.03.0,gcc@9.3.0,~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,linux-rhel8-ppc64le
+legion,20.03.0,gcc@10.2.0,~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,linux-rhel8-ppc64le
+legion,21.03.0,gcc@8.3.1,~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,linux-rhel8-ppc64le
+legion,21.03.0,gcc@9.1.0,~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,linux-rhel8-ppc64le
+legion,21.03.0,gcc@9.3.0,~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,linux-rhel8-ppc64le
+legion,21.03.0,gcc@10.2.0,~bindings~bounds_checks+cuda~cuda_hijack~cuda_unsupported_compiler~enable_tls~fortran~gasnet_debug+hdf5~hwloc~ipo~kokkos+libdl~native~openmp~papi~privilege_checks~python~redop_complex~shared~spy+zlib build_type=RelWithDebInfo conduit=none cuda_arch=70 gasnet_root=none max_dims=3 max_fields=512 network=none output_level=warning,linux-rhel8-ppc64le
+libarchive,3.5.1,gcc@8.3.1,,linux-rhel8-ppc64le
+libarchive,3.5.1,gcc@9.1.0,,linux-rhel8-ppc64le
+libarchive,3.5.1,gcc@9.3.0,,linux-rhel8-ppc64le
+libarchive,3.5.1,gcc@10.2.0,,linux-rhel8-ppc64le
+libarchive,3.5.1,gcc@11.1.0,,linux-rhel8-ppc64le
+libassuan,2.5.5,gcc@8.3.1,,linux-rhel8-ppc64le
+libbsd,0.11.3,gcc@7.5.0,,linux-rhel8-ppc64le
+libbsd,0.11.3,gcc@8.3.1,,linux-rhel8-ppc64le
+libbsd,0.11.3,gcc@9.1.0,,linux-rhel8-ppc64le
+libbsd,0.11.3,gcc@9.3.0,,linux-rhel8-ppc64le
+libbsd,0.11.3,gcc@10.2.0,,linux-rhel8-ppc64le
+libbsd,0.11.3,gcc@11.1.0,,linux-rhel8-ppc64le
+libcap,2.25,gcc@8.3.1, patches=3db844dd771b320b8117b72f4e00b560051311fbbd4cba1ebcbd7c19116c1d66,linux-rhel8-ppc64le
+libcap,2.25,gcc@9.1.0, patches=3db844dd771b320b8117b72f4e00b560051311fbbd4cba1ebcbd7c19116c1d66,linux-rhel8-ppc64le
+libcap,2.25,gcc@9.3.0, patches=3db844dd771b320b8117b72f4e00b560051311fbbd4cba1ebcbd7c19116c1d66,linux-rhel8-ppc64le
+libcap,2.25,gcc@10.2.0, patches=3db844dd771b320b8117b72f4e00b560051311fbbd4cba1ebcbd7c19116c1d66,linux-rhel8-ppc64le
+libcap,2.25,gcc@11.1.0, patches=3db844dd771b320b8117b72f4e00b560051311fbbd4cba1ebcbd7c19116c1d66,linux-rhel8-ppc64le
+libcerf,1.3,gcc@8.3.1,,linux-rhel8-ppc64le
+libcircle,0.3.0,gcc@8.3.1,,linux-rhel8-ppc64le
+libcircle,0.3.0,gcc@9.1.0,,linux-rhel8-ppc64le
+libcircle,0.3.0,gcc@9.3.0,,linux-rhel8-ppc64le
+libcircle,0.3.0,gcc@10.2.0,,linux-rhel8-ppc64le
+libcircle,0.3.0,gcc@11.1.0,,linux-rhel8-ppc64le
+libdwarf,20180129,gcc@8.3.1,,linux-rhel8-ppc64le
+libdwarf,20180129,gcc@8.3.1,,linux-rhel8-ppc64le
+libdwarf,20180129,gcc@9.1.0,,linux-rhel8-ppc64le
+libdwarf,20180129,gcc@9.1.0,,linux-rhel8-ppc64le
+libdwarf,20180129,gcc@9.3.0,,linux-rhel8-ppc64le
+libdwarf,20180129,gcc@9.3.0,,linux-rhel8-ppc64le
+libdwarf,20180129,gcc@10.2.0,,linux-rhel8-ppc64le
+libdwarf,20180129,gcc@10.2.0,,linux-rhel8-ppc64le
+libedit,3.1-20210216,gcc@8.3.1,,linux-rhel8-ppc64le
+libedit,3.1-20210216,gcc@9.1.0,,linux-rhel8-ppc64le
+libedit,3.1-20210216,gcc@9.3.0,,linux-rhel8-ppc64le
+libedit,3.1-20210216,gcc@10.2.0,,linux-rhel8-ppc64le
+libevent,2.1.8,gcc@8.3.1,+openssl,linux-rhel8-ppc64le
+libevent,2.1.12,gcc@8.3.1,+openssl,linux-rhel8-ppc64le
+libfabric,1.12.1,gcc@8.3.1,~kdreg fabrics=rxm,sockets,tcp,linux-rhel8-ppc64le
+libfabric,1.12.1,gcc@9.1.0,~kdreg fabrics=rxm,sockets,tcp,linux-rhel8-ppc64le
+libfabric,1.12.1,gcc@9.3.0,~kdreg fabrics=rxm,sockets,tcp,linux-rhel8-ppc64le
+libfabric,1.12.1,gcc@10.2.0,~kdreg fabrics=rxm,sockets,tcp,linux-rhel8-ppc64le
+libfabric,1.12.1,gcc@7.5.0,~kdreg fabrics=rxm,sockets,tcp,udp,verbs,linux-rhel8-ppc64le
+libfabric,1.12.1,gcc@8.3.1,~kdreg fabrics=rxm,sockets,tcp,udp,verbs,linux-rhel8-ppc64le
+libfabric,1.12.1,gcc@9.1.0,~kdreg fabrics=rxm,sockets,tcp,udp,verbs,linux-rhel8-ppc64le
+libfabric,1.12.1,gcc@9.3.0,~kdreg fabrics=rxm,sockets,tcp,udp,verbs,linux-rhel8-ppc64le
+libfabric,1.12.1,gcc@10.2.0,~kdreg fabrics=rxm,sockets,tcp,udp,verbs,linux-rhel8-ppc64le
+libfabric,1.12.1,gcc@11.1.0,~kdreg fabrics=rxm,sockets,tcp,udp,verbs,linux-rhel8-ppc64le
+libffi,3.3,gcc@7.5.0, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,linux-rhel8-ppc64le
+libffi,3.3,gcc@8.3.1, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,linux-rhel8-ppc64le
+libffi,3.3,gcc@9.1.0, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,linux-rhel8-ppc64le
+libffi,3.3,gcc@9.3.0, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,linux-rhel8-ppc64le
+libffi,3.3,gcc@10.2.0, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,linux-rhel8-ppc64le
+libffi,3.3,gcc@11.1.0, patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0,linux-rhel8-ppc64le
+libfontenc,1.1.3,gcc@8.3.1,,linux-rhel8-ppc64le
+libgcrypt,1.9.3,gcc@8.3.1,,linux-rhel8-ppc64le
+libgd,2.2.4,gcc@8.3.1,,linux-rhel8-ppc64le
+libgpg-error,1.42,gcc@8.3.1,,linux-rhel8-ppc64le
+libiberty,2.33.1,gcc@8.3.1,+pic,linux-rhel8-ppc64le
+libiberty,2.33.1,gcc@9.1.0,+pic,linux-rhel8-ppc64le
+libiberty,2.33.1,gcc@9.3.0,+pic,linux-rhel8-ppc64le
+libiberty,2.33.1,gcc@10.2.0,+pic,linux-rhel8-ppc64le
+libiberty,2.33.1,gcc@11.1.0,+pic,linux-rhel8-ppc64le
+libice,1.0.9,gcc@8.3.1,,linux-rhel8-ppc64le
+libiconv,1.16,gcc@7.5.0,,linux-rhel8-ppc64le
+libiconv,1.16,gcc@8.3.1,,linux-rhel8-ppc64le
+libiconv,1.16,gcc@9.1.0,,linux-rhel8-ppc64le
+libiconv,1.16,gcc@9.3.0,,linux-rhel8-ppc64le
+libiconv,1.16,gcc@10.2.0,,linux-rhel8-ppc64le
+libiconv,1.16,gcc@11.1.0,,linux-rhel8-ppc64le
+libiconv,1.16,xl@16.1.1-beta103,,linux-rhel8-ppc64le
+libiconv,1.16,xl@16.1.1-10,,linux-rhel8-ppc64le
+libidn2,2.3.0,gcc@8.3.1,,linux-rhel8-ppc64le
+libidn2,2.3.0,gcc@9.1.0,,linux-rhel8-ppc64le
+libidn2,2.3.0,gcc@9.3.0,,linux-rhel8-ppc64le
+libidn2,2.3.0,gcc@10.2.0,,linux-rhel8-ppc64le
+libjpeg-turbo,2.0.6,gcc@8.3.1,,linux-rhel8-ppc64le
+libksba,1.5.1,gcc@8.3.1,,linux-rhel8-ppc64le
+libmd,1.0.3,gcc@7.5.0,,linux-rhel8-ppc64le
+libmd,1.0.3,gcc@8.3.1,,linux-rhel8-ppc64le
+libmd,1.0.3,gcc@9.1.0,,linux-rhel8-ppc64le
+libmd,1.0.3,gcc@9.3.0,,linux-rhel8-ppc64le
+libmd,1.0.3,gcc@10.2.0,,linux-rhel8-ppc64le
+libmd,1.0.3,gcc@11.1.0,,linux-rhel8-ppc64le
+libmng,2.0.3,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+libmonitor,2021.04.27,gcc@8.3.1,~commrank~dlopen+hpctoolkit,linux-rhel8-ppc64le
+libmonitor,2021.04.27,gcc@9.1.0,~commrank~dlopen+hpctoolkit,linux-rhel8-ppc64le
+libmonitor,2021.04.27,gcc@9.3.0,~commrank~dlopen+hpctoolkit,linux-rhel8-ppc64le
+libmonitor,2021.04.27,gcc@10.2.0,~commrank~dlopen+hpctoolkit,linux-rhel8-ppc64le
+libmonitor,2021.04.27,gcc@8.3.1,~commrank+dlopen+hpctoolkit,linux-rhel8-ppc64le
+libmonitor,2021.04.27,gcc@9.1.0,~commrank+dlopen+hpctoolkit,linux-rhel8-ppc64le
+libmonitor,2021.04.27,gcc@9.3.0,~commrank+dlopen+hpctoolkit,linux-rhel8-ppc64le
+libmonitor,2021.04.27,gcc@10.2.0,~commrank+dlopen+hpctoolkit,linux-rhel8-ppc64le
+libpciaccess,0.16,gcc@8.3.1,,linux-rhel8-ppc64le
+libpciaccess,0.16,gcc@9.1.0,,linux-rhel8-ppc64le
+libpciaccess,0.16,gcc@9.3.0,,linux-rhel8-ppc64le
+libpciaccess,0.16,gcc@10.2.0,,linux-rhel8-ppc64le
+libpciaccess,0.16,gcc@11.1.0,,linux-rhel8-ppc64le
+libpfm4,4.11.0,gcc@8.3.1,,linux-rhel8-ppc64le
+libpfm4,4.11.0,gcc@9.1.0,,linux-rhel8-ppc64le
+libpfm4,4.11.0,gcc@9.3.0,,linux-rhel8-ppc64le
+libpfm4,4.11.0,gcc@10.2.0,,linux-rhel8-ppc64le
+libpng,1.6.37,gcc@7.5.0,,linux-rhel8-ppc64le
+libpng,1.6.37,gcc@8.3.1,,linux-rhel8-ppc64le
+libpng,1.6.37,gcc@9.1.0,,linux-rhel8-ppc64le
+libpng,1.6.37,gcc@9.3.0,,linux-rhel8-ppc64le
+libpng,1.6.37,gcc@10.2.0,,linux-rhel8-ppc64le
+libpng,1.6.37,gcc@11.1.0,,linux-rhel8-ppc64le
+libpthread-stubs,0.4,gcc@8.3.1,,linux-rhel8-ppc64le
+libquo,1.3.1,gcc@8.3.1,,linux-rhel8-ppc64le
+libquo,1.3.1,gcc@9.1.0,,linux-rhel8-ppc64le
+libquo,1.3.1,gcc@9.3.0,,linux-rhel8-ppc64le
+libquo,1.3.1,gcc@10.2.0,,linux-rhel8-ppc64le
+libquo,1.3.1,gcc@11.1.0,,linux-rhel8-ppc64le
+libsigsegv,2.13,gcc@7.5.0,,linux-rhel8-ppc64le
+libsigsegv,2.13,gcc@8-os,,linux-rhel8-ppc64le
+libsigsegv,2.13,gcc@8.3.1,,linux-rhel8-ppc64le
+libsigsegv,2.13,gcc@9.1.0,,linux-rhel8-ppc64le
+libsigsegv,2.13,gcc@9.3.0,,linux-rhel8-ppc64le
+libsigsegv,2.13,gcc@10.2.0,,linux-rhel8-ppc64le
+libsigsegv,2.13,gcc@11.1.0,,linux-rhel8-ppc64le
+libsm,1.2.3,gcc@8.3.1,,linux-rhel8-ppc64le
+libsodium,1.0.18,gcc@8.3.1,,linux-rhel8-ppc64le
+libtiff,4.1.0,gcc@8.3.1,,linux-rhel8-ppc64le
+libtool,2.4.6,gcc@8.3.1,,linux-rhel8-ppc64le
+libunistring,0.9.10,gcc@8.3.1,,linux-rhel8-ppc64le
+libunistring,0.9.10,gcc@9.1.0,,linux-rhel8-ppc64le
+libunistring,0.9.10,gcc@9.3.0,,linux-rhel8-ppc64le
+libunistring,0.9.10,gcc@10.2.0,,linux-rhel8-ppc64le
+libunwind,1.5.0,gcc@8.3.1,~pic~xz~zlib,linux-rhel8-ppc64le
+libunwind,1.5.0,gcc@9.1.0,~pic~xz~zlib,linux-rhel8-ppc64le
+libunwind,1.5.0,gcc@9.3.0,~pic~xz~zlib,linux-rhel8-ppc64le
+libunwind,1.5.0,gcc@10.2.0,~pic~xz~zlib,linux-rhel8-ppc64le
+libunwind,1.5.0,gcc@8.3.1,+pic+xz~zlib,linux-rhel8-ppc64le
+libunwind,1.5.0,gcc@9.1.0,+pic+xz~zlib,linux-rhel8-ppc64le
+libunwind,1.5.0,gcc@9.3.0,+pic+xz~zlib,linux-rhel8-ppc64le
+libunwind,1.5.0,gcc@10.2.0,+pic+xz~zlib,linux-rhel8-ppc64le
+libx11,1.7.0,gcc@8.3.1,,linux-rhel8-ppc64le
+libxau,1.0.8,gcc@8.3.1,,linux-rhel8-ppc64le
+libxcb,1.14,gcc@8.3.1,,linux-rhel8-ppc64le
+libxdmcp,1.1.2,gcc@8.3.1,,linux-rhel8-ppc64le
+libxext,1.3.3,gcc@8.3.1,,linux-rhel8-ppc64le
+libxfont,1.5.2,gcc@8.3.1,,linux-rhel8-ppc64le
+libxft,2.3.2,gcc@8.3.1,,linux-rhel8-ppc64le
+libxkbcommon,0.8.2,gcc@8.3.1,,linux-rhel8-ppc64le
+libxkbfile,1.0.9,gcc@8.3.1,,linux-rhel8-ppc64le
+libxml2,2.9.10,gcc@7.5.0,~python,linux-rhel8-ppc64le
+libxml2,2.9.10,gcc@8.3.1,~python,linux-rhel8-ppc64le
+libxml2,2.9.10,gcc@8.3.1,~python,linux-rhel8-ppc64le
+libxml2,2.9.10,gcc@9.1.0,~python,linux-rhel8-ppc64le
+libxml2,2.9.10,gcc@9.1.0,~python,linux-rhel8-ppc64le
+libxml2,2.9.10,gcc@9.3.0,~python,linux-rhel8-ppc64le
+libxml2,2.9.10,gcc@9.3.0,~python,linux-rhel8-ppc64le
+libxml2,2.9.10,gcc@10.2.0,~python,linux-rhel8-ppc64le
+libxml2,2.9.10,gcc@10.2.0,~python,linux-rhel8-ppc64le
+libxml2,2.9.10,gcc@11.1.0,~python,linux-rhel8-ppc64le
+libxpm,3.5.12,gcc@8.3.1,,linux-rhel8-ppc64le
+libxrender,0.9.10,gcc@8.3.1,,linux-rhel8-ppc64le
+libzmq,4.3.3,gcc@8.3.1,~drafts+libsodium,linux-rhel8-ppc64le
+log4c,1.2.4,gcc@8.3.1,,linux-rhel8-ppc64le
+lua,5.3.5,gcc@8.3.1,~pcfile+shared,linux-rhel8-ppc64le
+lua,5.3.5,gcc@9.1.0,~pcfile+shared,linux-rhel8-ppc64le
+lua,5.3.5,gcc@9.3.0,~pcfile+shared,linux-rhel8-ppc64le
+lua,5.3.5,gcc@10.2.0,~pcfile+shared,linux-rhel8-ppc64le
+lwgrp,1.0.3,gcc@8.3.1,,linux-rhel8-ppc64le
+lwgrp,1.0.3,gcc@9.1.0,,linux-rhel8-ppc64le
+lwgrp,1.0.3,gcc@9.3.0,,linux-rhel8-ppc64le
+lwgrp,1.0.3,gcc@10.2.0,,linux-rhel8-ppc64le
+lwgrp,1.0.3,gcc@11.1.0,,linux-rhel8-ppc64le
+lz4,1.9.3,gcc@7.5.0, libs=shared,static,linux-rhel8-ppc64le
+lz4,1.9.3,gcc@8.3.1, libs=shared,static,linux-rhel8-ppc64le
+lz4,1.9.3,gcc@9.1.0, libs=shared,static,linux-rhel8-ppc64le
+lz4,1.9.3,gcc@9.3.0, libs=shared,static,linux-rhel8-ppc64le
+lz4,1.9.3,gcc@10.2.0, libs=shared,static,linux-rhel8-ppc64le
+lz4,1.9.3,gcc@11.1.0, libs=shared,static,linux-rhel8-ppc64le
+lzo,2.10,gcc@8.3.1, libs=shared,static,linux-rhel8-ppc64le
+lzo,2.10,gcc@9.1.0, libs=shared,static,linux-rhel8-ppc64le
+lzo,2.10,gcc@9.3.0, libs=shared,static,linux-rhel8-ppc64le
+lzo,2.10,gcc@10.2.0, libs=shared,static,linux-rhel8-ppc64le
+lzo,2.10,gcc@11.1.0, libs=shared,static,linux-rhel8-ppc64le
+m4,1.4.18,gcc@7.5.0,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,linux-rhel8-ppc64le
+m4,1.4.18,gcc@8-os,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,linux-rhel8-ppc64le
+m4,1.4.18,gcc@8.3.1,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,linux-rhel8-ppc64le
+m4,1.4.18,gcc@9.1.0,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,linux-rhel8-ppc64le
+m4,1.4.18,gcc@9.3.0,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,linux-rhel8-ppc64le
+m4,1.4.18,gcc@10.2.0,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,linux-rhel8-ppc64le
+m4,1.4.18,gcc@11.1.0,+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8,linux-rhel8-ppc64le
+magma,2.5.3,gcc@8.3.1,+cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+magma,2.5.4,gcc@8.3.1,+cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+magma,2.5.4,gcc@9.1.0,+cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+magma,2.5.4,gcc@9.3.0,+cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+magma,2.5.4,gcc@10.2.0,+cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+magma,2.6.1,nvhpc@21.7,+cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=9fbcf5ad5b7f9713c6ecfe3887d043d393c368e1fa29e2a2ece77e71f64b641d,linux-rhel8-ppc64le
+magma,2.6.1,gcc@8.3.1,+cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+magma,2.6.1,gcc@9.1.0,+cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+magma,2.6.1,gcc@9.3.0,+cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+magma,2.6.1,gcc@10.2.0,+cuda+fortran~ipo~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+makedepend,1.0.5,gcc@8.3.1,,linux-rhel8-ppc64le
+matio,1.5.17,gcc@8.3.1,+hdf5+shared+zlib,linux-rhel8-ppc64le
+matio,1.5.17,gcc@9.1.0,+hdf5+shared+zlib,linux-rhel8-ppc64le
+matio,1.5.17,gcc@9.3.0,+hdf5+shared+zlib,linux-rhel8-ppc64le
+matio,1.5.17,gcc@10.2.0,+hdf5+shared+zlib,linux-rhel8-ppc64le
+mbedtls,2.16.9,gcc@8.3.1,~ipo+pic build_type=Release,linux-rhel8-ppc64le
+mbedtls,2.16.9,gcc@9.1.0,~ipo+pic build_type=Release,linux-rhel8-ppc64le
+mbedtls,2.16.9,gcc@9.3.0,~ipo+pic build_type=Release,linux-rhel8-ppc64le
+mbedtls,2.16.9,gcc@10.2.0,~ipo+pic build_type=Release,linux-rhel8-ppc64le
+mercurial,5.8,gcc@8.3.1,,linux-rhel8-ppc64le
+mercury,1.0.1,gcc@8.3.1,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo patches=34fc95b3599c74a8cece6e873cfdc8bc0afe2dc0deabb6e2d11ea2a93f0cebf5,linux-rhel8-ppc64le
+mercury,1.0.1,gcc@9.1.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo patches=34fc95b3599c74a8cece6e873cfdc8bc0afe2dc0deabb6e2d11ea2a93f0cebf5,linux-rhel8-ppc64le
+mercury,1.0.1,gcc@9.3.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo patches=34fc95b3599c74a8cece6e873cfdc8bc0afe2dc0deabb6e2d11ea2a93f0cebf5,linux-rhel8-ppc64le
+mercury,2.0.0,gcc@8.3.1,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.0,gcc@9.1.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.0,gcc@9.3.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.0,gcc@10.2.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.1,gcc@8.3.1,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.1,gcc@8.3.1,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.1,gcc@9.1.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.1,gcc@9.1.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.1,gcc@9.3.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.1,gcc@9.3.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.1,gcc@10.2.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.1,gcc@10.2.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+mercury,2.0.1,gcc@11.1.0,~bmi+boostsys~cci+checksum~debug~ipo~mpi+ofi+shared+sm~udreg build_type=RelWithDebInfo,linux-rhel8-ppc64le
+meson,0.58.0,gcc@8.3.1, patches=aa6c50d5a2aeb1a487d16f6712be4357fefb923aae37ab830699b07338388287,linux-rhel8-ppc64le
+metis,5.1.0,gcc@8.3.1,~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2,linux-rhel8-ppc64le
+metis,5.1.0,gcc@9.1.0,~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2,linux-rhel8-ppc64le
+metis,5.1.0,gcc@9.3.0,~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2,linux-rhel8-ppc64le
+metis,5.1.0,gcc@10.2.0,~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2,linux-rhel8-ppc64le
+metis,5.1.0,gcc@11.1.0,~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2,linux-rhel8-ppc64le
+mkfontdir,1.0.7,gcc@8.3.1,,linux-rhel8-ppc64le
+mkfontscale,1.1.2,gcc@8.3.1,,linux-rhel8-ppc64le
+mochi-margo,0.9.4,gcc@8.3.1,,linux-rhel8-ppc64le
+mochi-margo,0.9.4,gcc@9.1.0,,linux-rhel8-ppc64le
+mochi-margo,0.9.4,gcc@9.3.0,,linux-rhel8-ppc64le
+mochi-margo,0.9.4,gcc@10.2.0,,linux-rhel8-ppc64le
+mpark-variant,1.4.0,gcc@8.3.1,~ipo build_type=RelWithDebInfo patches=21a4f8de3525204ee6db2e53758a3e3fd9c13817df29d2926d24376858a369e7,4e173fe8c853eb92956a40371688b4a19498189fe65b7ceac30f6b9d6663a985,b3501f726fd40129b4aaa11453a5891c8953a34af8ac84f5ab10a22afa5e7b9b,linux-rhel8-ppc64le
+mpark-variant,1.4.0,gcc@9.1.0,~ipo build_type=RelWithDebInfo patches=21a4f8de3525204ee6db2e53758a3e3fd9c13817df29d2926d24376858a369e7,4e173fe8c853eb92956a40371688b4a19498189fe65b7ceac30f6b9d6663a985,b3501f726fd40129b4aaa11453a5891c8953a34af8ac84f5ab10a22afa5e7b9b,linux-rhel8-ppc64le
+mpark-variant,1.4.0,gcc@9.3.0,~ipo build_type=RelWithDebInfo patches=21a4f8de3525204ee6db2e53758a3e3fd9c13817df29d2926d24376858a369e7,4e173fe8c853eb92956a40371688b4a19498189fe65b7ceac30f6b9d6663a985,b3501f726fd40129b4aaa11453a5891c8953a34af8ac84f5ab10a22afa5e7b9b,linux-rhel8-ppc64le
+mpark-variant,1.4.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo patches=21a4f8de3525204ee6db2e53758a3e3fd9c13817df29d2926d24376858a369e7,4e173fe8c853eb92956a40371688b4a19498189fe65b7ceac30f6b9d6663a985,b3501f726fd40129b4aaa11453a5891c8953a34af8ac84f5ab10a22afa5e7b9b,linux-rhel8-ppc64le
+mpark-variant,1.4.0,gcc@11.1.0,~ipo build_type=RelWithDebInfo patches=21a4f8de3525204ee6db2e53758a3e3fd9c13817df29d2926d24376858a369e7,4e173fe8c853eb92956a40371688b4a19498189fe65b7ceac30f6b9d6663a985,b3501f726fd40129b4aaa11453a5891c8953a34af8ac84f5ab10a22afa5e7b9b,linux-rhel8-ppc64le
+mpfr,4.1.0,gcc@8.3.1,,linux-rhel8-ppc64le
+mpfr,4.1.0,gcc@9.1.0,,linux-rhel8-ppc64le
+mpfr,4.1.0,gcc@9.3.0,,linux-rhel8-ppc64le
+mpfr,4.1.0,gcc@10.2.0,,linux-rhel8-ppc64le
+mpifileutils,0.10.1,gcc@8.3.1,~experimental~gpfs~lustre+xattr,linux-rhel8-ppc64le
+mpifileutils,0.10.1,gcc@9.1.0,~experimental~gpfs~lustre+xattr,linux-rhel8-ppc64le
+mpifileutils,0.10.1,gcc@9.3.0,~experimental~gpfs~lustre+xattr,linux-rhel8-ppc64le
+mpifileutils,0.10.1,gcc@10.2.0,~experimental~gpfs~lustre+xattr,linux-rhel8-ppc64le
+mpifileutils,0.11,gcc@8.3.1,~experimental~gpfs~lustre+xattr,linux-rhel8-ppc64le
+mpifileutils,0.11,gcc@9.1.0,~experimental~gpfs~lustre+xattr,linux-rhel8-ppc64le
+mpifileutils,0.11,gcc@9.3.0,~experimental~gpfs~lustre+xattr,linux-rhel8-ppc64le
+mpifileutils,0.11,gcc@10.2.0,~experimental~gpfs~lustre+xattr,linux-rhel8-ppc64le
+mpifileutils,0.11,gcc@11.1.0,~experimental~gpfs~lustre+xattr,linux-rhel8-ppc64le
+mpip,3.5,gcc@7.5.0,~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8,linux-rhel8-ppc64le
+mpip,3.5,gcc@8.3.1,~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8,linux-rhel8-ppc64le
+mpip,3.5,gcc@9.1.0,~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8,linux-rhel8-ppc64le
+mpip,3.5,gcc@9.3.0,~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8,linux-rhel8-ppc64le
+mpip,3.5,gcc@10.2.0,~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8,linux-rhel8-ppc64le
+mpip,3.5,gcc@11.1.0,~add_shared_target+bfd+demangling+libunwind+mpi_io+mpi_nbc+mpi_rma~setjmp internal_stackdepth=3 maxargs=32 stackdepth=8,linux-rhel8-ppc64le
+mumps,5.4.0,gcc@8.3.1,~blr_mt+complex+double+float~int64~metis+mpi~openmp~parmetis~ptscotch~scotch+shared patches=1946864d2106f7414aaa4dbd4dbc068b7804af7c1588381e814b268a56140a52,linux-rhel8-ppc64le
+mumps,5.4.0,gcc@9.1.0,~blr_mt+complex+double+float~int64~metis+mpi~openmp~parmetis~ptscotch~scotch+shared patches=1946864d2106f7414aaa4dbd4dbc068b7804af7c1588381e814b268a56140a52,linux-rhel8-ppc64le
+mumps,5.4.0,gcc@9.3.0,~blr_mt+complex+double+float~int64~metis+mpi~openmp~parmetis~ptscotch~scotch+shared patches=1946864d2106f7414aaa4dbd4dbc068b7804af7c1588381e814b268a56140a52,linux-rhel8-ppc64le
+mumps,5.4.0,gcc@10.2.0,~blr_mt+complex+double+float~int64~metis+mpi~openmp~parmetis~ptscotch~scotch+shared patches=1946864d2106f7414aaa4dbd4dbc068b7804af7c1588381e814b268a56140a52,linux-rhel8-ppc64le
+nano,4.9,gcc@8.3.1,,linux-rhel8-ppc64le
+nasm,2.15.05,gcc@8.3.1,,linux-rhel8-ppc64le
+nco,4.9.3,gcc@8.3.1,~doc~mpi~mpi-deps,linux-rhel8-ppc64le
+nco,4.9.3,gcc@8.3.1,~doc~mpi+mpi-deps,linux-rhel8-ppc64le
+nco,4.9.3,gcc@9.1.0,~doc~mpi+mpi-deps,linux-rhel8-ppc64le
+nco,4.9.3,gcc@9.3.0,~doc~mpi+mpi-deps,linux-rhel8-ppc64le
+ncurses,6.2,gcc@7.5.0,~symlinks+termlib abi=none,linux-rhel8-ppc64le
+ncurses,6.2,gcc@8-os,~symlinks+termlib abi=none,linux-rhel8-ppc64le
+ncurses,6.2,gcc@8.3.1,~symlinks+termlib abi=none,linux-rhel8-ppc64le
+ncurses,6.2,gcc@9.1.0,~symlinks+termlib abi=none,linux-rhel8-ppc64le
+ncurses,6.2,gcc@9.3.0,~symlinks+termlib abi=none,linux-rhel8-ppc64le
+ncurses,6.2,gcc@10.2.0,~symlinks+termlib abi=none,linux-rhel8-ppc64le
+ncurses,6.2,gcc@11.1.0,~symlinks+termlib abi=none,linux-rhel8-ppc64le
+netcdf-c,4.8.0,gcc@8.3.1,~dap~fsync~hdf4~jna~mpi~parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,gcc@7.5.0,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,gcc@8.3.1,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,gcc@9.1.0,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,gcc@9.3.0,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,gcc@10.2.0,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,gcc@11.1.0,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,nvhpc@20.9,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,nvhpc@21.2,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,nvhpc@21.3,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,nvhpc@21.5,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,nvhpc@21.7,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,pgi@20.1,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,pgi@20.4,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-c,4.8.0,xl@16.1.1-10,~dap~fsync~hdf4~jna+mpi+parallel-netcdf+pic+shared,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,gcc@7.5.0,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,gcc@8.3.1,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,gcc@9.1.0,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,gcc@9.3.0,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,gcc@10.2.0,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,gcc@11.1.0,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,nvhpc@20.9,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,nvhpc@21.2,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,nvhpc@21.3,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,nvhpc@21.5,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,nvhpc@21.7,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,pgi@20.1,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,pgi@20.4,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-cxx4,4.3.1,xl@16.1.1-10,~doxygen+pic+shared+static,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,gcc@7.5.0,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,gcc@8.3.1,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,gcc@9.1.0,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,gcc@9.3.0,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,gcc@10.2.0,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,gcc@11.1.0,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,nvhpc@20.9,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,nvhpc@21.2,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,nvhpc@21.3,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,nvhpc@21.5,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,nvhpc@21.7,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,pgi@20.1,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,pgi@20.4,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netcdf-fortran,4.4.5,xl@16.1.1-10,~doc+pic+shared patches=55fef65a4652fc5b8114db25bc558c762d9d4d287377a7db0ea2a2937d625e44,ef26f0860c0d258af7ba28780a981545a8a1c053dbdabe2d656d6e40ce1c7c06,linux-rhel8-ppc64le
+netlib-lapack,3.8.0,xl@16.1.1-beta103,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo patches=0046d24487c0b7cbc84527fc36300d4e970cb4191b44e8b1619523fae15137f1,5c79286f3d08a0b0f1f3acba2a92ee698647716ba8c6c0ae20c9cc2713e6f139,ad3d41fe9ff94b7661e09fceaf2b2e4b8c83510c1465c016e161541b4429b5ee,linux-rhel8-ppc64le
+netlib-lapack,3.8.0,xl@16.1.1-10,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo patches=0046d24487c0b7cbc84527fc36300d4e970cb4191b44e8b1619523fae15137f1,5c79286f3d08a0b0f1f3acba2a92ee698647716ba8c6c0ae20c9cc2713e6f139,ad3d41fe9ff94b7661e09fceaf2b2e4b8c83510c1465c016e161541b4429b5ee,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,gcc@7.5.0,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,gcc@8.3.1,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,gcc@9.1.0,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,gcc@9.3.0,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,gcc@10.2.0,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,gcc@11.1.0,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,nvhpc@20.9,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,nvhpc@21.2,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,nvhpc@21.3,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,nvhpc@21.5,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,nvhpc@21.7,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,pgi@20.1,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-lapack,3.9.1,pgi@20.4,~external-blas~ipo+lapacke+shared~xblas build_type=RelWithDebInfo,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@7.5.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@8.3.1,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@8.3.1,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@8.3.1,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@9.1.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@9.1.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@9.1.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@9.3.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@9.3.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@9.3.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@10.2.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@10.2.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@10.2.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,gcc@11.1.0,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,pgi@20.4,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,xl@16.1.1-beta103,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+netlib-scalapack,2.1.0,xl@16.1.1-10,~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2,linux-rhel8-ppc64le
+nettle,3.4.1,gcc@8.3.1,,linux-rhel8-ppc64le
+nettle,3.4.1,gcc@9.1.0,,linux-rhel8-ppc64le
+nettle,3.4.1,gcc@9.3.0,,linux-rhel8-ppc64le
+nettle,3.4.1,gcc@10.2.0,,linux-rhel8-ppc64le
+nettle,3.4.1,gcc@11.1.0,,linux-rhel8-ppc64le
+ninja,1.10.1,gcc@8.3.1,,linux-rhel8-ppc64le
+ninja,1.10.1,gcc@9.1.0,,linux-rhel8-ppc64le
+ninja,1.10.1,gcc@9.3.0,,linux-rhel8-ppc64le
+ninja,1.10.1,gcc@10.2.0,,linux-rhel8-ppc64le
+ninja,1.10.2,gcc@8.3.1,,linux-rhel8-ppc64le
+ninja,1.10.2,gcc@9.1.0,,linux-rhel8-ppc64le
+ninja,1.10.2,gcc@9.3.0,,linux-rhel8-ppc64le
+ninja,1.10.2,gcc@10.2.0,,linux-rhel8-ppc64le
+ninja,1.10.2,gcc@11.1.0,,linux-rhel8-ppc64le
+nlohmann-json,3.9.1,gcc@8.3.1,~ipo+single_header build_type=RelWithDebInfo,linux-rhel8-ppc64le
+nlohmann-json,3.9.1,gcc@9.1.0,~ipo+single_header build_type=RelWithDebInfo,linux-rhel8-ppc64le
+nlohmann-json,3.9.1,gcc@9.3.0,~ipo+single_header build_type=RelWithDebInfo,linux-rhel8-ppc64le
+nlohmann-json,3.9.1,gcc@10.2.0,~ipo+single_header build_type=RelWithDebInfo,linux-rhel8-ppc64le
+nlohmann-json,3.9.1,gcc@11.1.0,~ipo+single_header build_type=RelWithDebInfo,linux-rhel8-ppc64le
+npth,1.6,gcc@8.3.1,,linux-rhel8-ppc64le
+numactl,2.0.14,gcc@7.5.0, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,linux-rhel8-ppc64le
+numactl,2.0.14,gcc@8-os, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,linux-rhel8-ppc64le
+numactl,2.0.14,gcc@8.3.1, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,linux-rhel8-ppc64le
+numactl,2.0.14,gcc@9.1.0, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,linux-rhel8-ppc64le
+numactl,2.0.14,gcc@9.3.0, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,linux-rhel8-ppc64le
+numactl,2.0.14,gcc@10.2.0, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,linux-rhel8-ppc64le
+numactl,2.0.14,gcc@11.1.0, patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,linux-rhel8-ppc64le
+omega-h,9.32.5,gcc@8.3.1,~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo,linux-rhel8-ppc64le
+omega-h,9.32.5,gcc@9.1.0,~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo,linux-rhel8-ppc64le
+omega-h,9.32.5,gcc@9.3.0,~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo,linux-rhel8-ppc64le
+omega-h,9.32.5,gcc@10.2.0,~examples~ipo+mpi+optimize+shared+symbols~throw+trilinos~warnings+zlib build_type=RelWithDebInfo,linux-rhel8-ppc64le
+opari2,2.0.6,gcc@8.3.1,,linux-rhel8-ppc64le
+openblas,0.3.5,gcc@8.3.1,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared patches=865703b4f405543bbd583413fdeff2226dfda908be33639276c06e5aa7ae2cae threads=openmp,linux-rhel8-ppc64le
+openblas,0.3.5,gcc@9.1.0,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared patches=865703b4f405543bbd583413fdeff2226dfda908be33639276c06e5aa7ae2cae threads=openmp,linux-rhel8-ppc64le
+openblas,0.3.5,gcc@9.3.0,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared patches=865703b4f405543bbd583413fdeff2226dfda908be33639276c06e5aa7ae2cae threads=openmp,linux-rhel8-ppc64le
+openblas,0.3.5,gcc@10.2.0,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared patches=865703b4f405543bbd583413fdeff2226dfda908be33639276c06e5aa7ae2cae threads=openmp,linux-rhel8-ppc64le
+openblas,0.3.15,gcc@9.3.0,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=none,linux-rhel8-ppc64le
+openblas,0.3.15,gcc@8.3.1,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=openmp,linux-rhel8-ppc64le
+openblas,0.3.15,gcc@9.1.0,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=openmp,linux-rhel8-ppc64le
+openblas,0.3.15,gcc@9.3.0,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=openmp,linux-rhel8-ppc64le
+openblas,0.3.15,gcc@10.2.0,~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=openmp,linux-rhel8-ppc64le
+openjdk,11.0.9.1_1,gcc@8.3.1,,linux-rhel8-ppc64le
+openjdk,11.0.9.1_1,gcc@9.1.0,,linux-rhel8-ppc64le
+openjdk,11.0.9.1_1,gcc@9.3.0,,linux-rhel8-ppc64le
+openjdk,11.0.9.1_1,gcc@10.2.0,,linux-rhel8-ppc64le
+openjdk,11.0.9.1_1,gcc@11.1.0,,linux-rhel8-ppc64le
+openpmd-api,0.12.0,gcc@8.3.1,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.12.0,gcc@9.1.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.12.0,gcc@9.3.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.12.0,gcc@10.2.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.13.2,gcc@8.3.1,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.13.2,gcc@9.1.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.13.2,gcc@9.3.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.13.2,gcc@10.2.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.13.4,gcc@8.3.1,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.13.4,gcc@9.1.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.13.4,gcc@9.3.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.13.4,gcc@10.2.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openpmd-api,0.13.4,gcc@11.1.0,~adios1+adios2+hdf5~ipo+mpi~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+openssh,8.5p1,gcc@8.3.1,,linux-rhel8-ppc64le
+openssh,8.5p1,gcc@9.1.0,,linux-rhel8-ppc64le
+openssh,8.5p1,gcc@9.3.0,,linux-rhel8-ppc64le
+openssh,8.5p1,gcc@10.2.0,,linux-rhel8-ppc64le
+openssl,1.1.1,gcc@7.5.0,~docs+systemcerts,linux-rhel8-ppc64le
+openssl,1.1.1,gcc@8-os,~docs+systemcerts,linux-rhel8-ppc64le
+openssl,1.1.1,gcc@8.3.1,~docs+systemcerts,linux-rhel8-ppc64le
+openssl,1.1.1,gcc@9.1.0,~docs+systemcerts,linux-rhel8-ppc64le
+openssl,1.1.1,gcc@9.3.0,~docs+systemcerts,linux-rhel8-ppc64le
+openssl,1.1.1,gcc@10.2.0,~docs+systemcerts,linux-rhel8-ppc64le
+openssl,1.1.1,gcc@11.1.0,~docs+systemcerts,linux-rhel8-ppc64le
+otf2,2.3,gcc@8.3.1,,linux-rhel8-ppc64le
+otf2,2.3,gcc@9.1.0,,linux-rhel8-ppc64le
+otf2,2.3,gcc@9.3.0,,linux-rhel8-ppc64le
+otf2,2.3,gcc@10.2.0,,linux-rhel8-ppc64le
+pango,1.41.0,gcc@8.3.1,~X,linux-rhel8-ppc64le
+pango,1.41.0,gcc@8.3.1,+X,linux-rhel8-ppc64le
+papi,6.0.0.1,gcc@8.3.1,~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,linux-rhel8-ppc64le
+papi,6.0.0.1,gcc@9.1.0,~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,linux-rhel8-ppc64le
+papi,6.0.0.1,gcc@9.3.0,~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,linux-rhel8-ppc64le
+papi,6.0.0.1,gcc@10.2.0,~cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,linux-rhel8-ppc64le
+papi,6.0.0.1,gcc@8.3.1,+cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,linux-rhel8-ppc64le
+papi,6.0.0.1,gcc@8.3.1,+cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,linux-rhel8-ppc64le
+papi,6.0.0.1,gcc@9.1.0,+cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,linux-rhel8-ppc64le
+papi,6.0.0.1,gcc@9.3.0,+cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,linux-rhel8-ppc64le
+papi,6.0.0.1,gcc@10.2.0,+cuda+example~infiniband~lmsensors~nvml~powercap~rapl~sde+shared~static_tools,linux-rhel8-ppc64le
+papyrus,1.0.0,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+papyrus,1.0.0,gcc@9.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+papyrus,1.0.0,gcc@9.3.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+papyrus,1.0.0,gcc@10.2.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+papyrus,1.0.1,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+papyrus,1.0.1,gcc@9.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+papyrus,1.0.1,gcc@9.3.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+papyrus,1.0.1,gcc@10.2.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+papyrus,1.0.1,gcc@11.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.3.0,xl@16.1.1-10,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,gcc@7.5.0,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,gcc@8.3.1,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,gcc@9.1.0,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,gcc@9.3.0,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,gcc@10.2.0,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,gcc@11.1.0,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,nvhpc@20.9,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,nvhpc@21.2,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,nvhpc@21.3,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,nvhpc@21.5,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,nvhpc@21.7,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,pgi@20.1,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-io,2.4.4,pgi@20.4,~examples~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+parallel-netcdf,1.12.1,gcc@8.3.1,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.1,gcc@9.1.0,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.1,gcc@9.3.0,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.1,gcc@10.2.0,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,gcc@7.5.0,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,gcc@8.3.1,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,gcc@9.1.0,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,gcc@9.3.0,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,gcc@10.2.0,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,gcc@11.1.0,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,nvhpc@20.9,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,nvhpc@21.2,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,nvhpc@21.3,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,nvhpc@21.5,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,nvhpc@21.7,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,pgi@20.1,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,pgi@20.4,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,xl@16.1.1-beta103,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parallel-netcdf,1.12.2,xl@16.1.1-10,~burstbuffer+cxx+fortran+pic+shared,linux-rhel8-ppc64le
+parmetis,4.0.3,gcc@8.3.1,~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d,linux-rhel8-ppc64le
+parmetis,4.0.3,gcc@9.1.0,~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d,linux-rhel8-ppc64le
+parmetis,4.0.3,gcc@9.3.0,~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d,linux-rhel8-ppc64le
+parmetis,4.0.3,gcc@10.2.0,~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d,linux-rhel8-ppc64le
+parmetis,4.0.3,gcc@11.1.0,~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d,linux-rhel8-ppc64le
+patchelf,0.12,gcc@8.3.1, patches=a155f233b228f02d7886e304cb13898d93801b52f351e098c2cc0719697ec9d0,linux-rhel8-ppc64le
+pcre,8.44,gcc@8.3.1,~jit+multibyte+utf,linux-rhel8-ppc64le
+pcre,8.44,gcc@9.1.0,~jit+multibyte+utf,linux-rhel8-ppc64le
+pcre,8.44,gcc@9.3.0,~jit+multibyte+utf,linux-rhel8-ppc64le
+pcre,8.44,gcc@10.2.0,~jit+multibyte+utf,linux-rhel8-ppc64le
+pcre,8.44,gcc@11.1.0,~jit+multibyte+utf,linux-rhel8-ppc64le
+pcre2,10.36,gcc@8.3.1,~jit+multibyte,linux-rhel8-ppc64le
+pcre2,10.36,gcc@9.1.0,~jit+multibyte,linux-rhel8-ppc64le
+pcre2,10.36,gcc@9.3.0,~jit+multibyte,linux-rhel8-ppc64le
+pcre2,10.36,gcc@10.2.0,~jit+multibyte,linux-rhel8-ppc64le
+pdt,3.25.1,gcc@8.3.1,~pic,linux-rhel8-ppc64le
+pdt,3.25.1,gcc@9.1.0,~pic,linux-rhel8-ppc64le
+pdt,3.25.1,gcc@9.3.0,~pic,linux-rhel8-ppc64le
+pdt,3.25.1,gcc@10.2.0,~pic,linux-rhel8-ppc64le
+pdt,3.25.1,gcc@11.1.0,~pic,linux-rhel8-ppc64le
+perl,5.30.1,gcc@7.5.0,+cpanm+shared+threads,linux-rhel8-ppc64le
+perl,5.30.1,gcc@8-os,+cpanm+shared+threads,linux-rhel8-ppc64le
+perl,5.30.1,gcc@8.3.1,+cpanm+shared+threads,linux-rhel8-ppc64le
+perl,5.30.1,gcc@9.1.0,+cpanm+shared+threads,linux-rhel8-ppc64le
+perl,5.30.1,gcc@9.3.0,+cpanm+shared+threads,linux-rhel8-ppc64le
+perl,5.30.1,gcc@10.2.0,+cpanm+shared+threads,linux-rhel8-ppc64le
+perl,5.30.1,gcc@11.1.0,+cpanm+shared+threads,linux-rhel8-ppc64le
+petsc,3.14.0,gcc@8.3.1,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.0,gcc@9.1.0,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.0,gcc@9.3.0,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.0,gcc@10.2.0,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.4,gcc@8.3.1,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.4,gcc@9.1.0,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.4,gcc@9.3.0,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.4,gcc@10.2.0,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.6,gcc@8.3.1,~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.6,gcc@9.1.0,~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.6,gcc@9.3.0,~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.14.6,gcc@10.2.0,~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.15.0,gcc@8.3.1,~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.15.0,gcc@9.1.0,~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.15.0,gcc@9.3.0,~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.15.0,gcc@10.2.0,~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.15.0,gcc@8.3.1,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.15.0,gcc@9.1.0,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.15.0,gcc@9.3.0,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+petsc,3.15.0,gcc@10.2.0,~X~batch~cgns~complex+cuda~debug+double~exodusii~fftw~giflib+hdf5+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~moab~mpfr+mpi~mumps~p4est~ptscotch~random123~saws+shared~suite-sparse+superlu-dist~trilinos~valgrind clanguage=C,linux-rhel8-ppc64le
+pfunit,3.3.3,gcc@8.3.1,~docs~ipo~mpi~openmp+shared~use_comm_world build_type=RelWithDebInfo max_array_rank=5,linux-rhel8-ppc64le
+pfunit,3.3.3,gcc@9.1.0,~docs~ipo~mpi~openmp+shared~use_comm_world build_type=RelWithDebInfo max_array_rank=5,linux-rhel8-ppc64le
+pfunit,3.3.3,gcc@9.3.0,~docs~ipo~mpi~openmp+shared~use_comm_world build_type=RelWithDebInfo max_array_rank=5,linux-rhel8-ppc64le
+pfunit,3.3.3,gcc@10.2.0,~docs~ipo~mpi~openmp+shared~use_comm_world build_type=RelWithDebInfo max_array_rank=5,linux-rhel8-ppc64le
+pfunit,3.3.3,gcc@11.1.0,~docs~ipo~mpi~openmp+shared~use_comm_world build_type=RelWithDebInfo max_array_rank=5,linux-rhel8-ppc64le
+pgi,20.1,gcc@8-os,~amd~java+managed+mpi+mpigpu~network+nvidia+single,linux-rhel8-ppc64le
+pgi,20.4,gcc@8-os,~amd~java+managed+mpi+mpigpu~network+nvidia+single,linux-rhel8-ppc64le
+pinentry,1.1.1,gcc@8.3.1,,linux-rhel8-ppc64le
+pixman,0.40.0,gcc@8.3.1,,linux-rhel8-ppc64le
+pkgconf,1.7.4,gcc@7.5.0,,linux-rhel8-ppc64le
+pkgconf,1.7.4,gcc@8-os,,linux-rhel8-ppc64le
+pkgconf,1.7.4,gcc@8.3.1,,linux-rhel8-ppc64le
+pkgconf,1.7.4,gcc@9.1.0,,linux-rhel8-ppc64le
+pkgconf,1.7.4,gcc@9.3.0,,linux-rhel8-ppc64le
+pkgconf,1.7.4,gcc@10.2.0,,linux-rhel8-ppc64le
+pkgconf,1.7.4,gcc@11.1.0,,linux-rhel8-ppc64le
+plasma,20.9.20,gcc@8.3.1,~ipo~lua+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+plasma,20.9.20,gcc@9.1.0,~ipo~lua+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+plasma,20.9.20,gcc@9.3.0,~ipo~lua+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+plasma,20.9.20,gcc@10.2.0,~ipo~lua+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+plasma,20.9.20,gcc@11.1.0,~ipo~lua+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+precice,2.2.0,gcc@8.3.1,~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+precice,2.2.0,gcc@9.1.0,~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+precice,2.2.0,gcc@9.3.0,~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+precice,2.2.0,gcc@10.2.0,~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+precice,2.2.1,gcc@8.3.1,~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+precice,2.2.1,gcc@9.1.0,~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+precice,2.2.1,gcc@9.3.0,~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+precice,2.2.1,gcc@10.2.0,~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo,linux-rhel8-ppc64le
+pumi,2.2.2,gcc@8.3.1,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,linux-rhel8-ppc64le
+pumi,2.2.2,gcc@9.1.0,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,linux-rhel8-ppc64le
+pumi,2.2.2,gcc@9.3.0,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,linux-rhel8-ppc64le
+pumi,2.2.2,gcc@10.2.0,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,linux-rhel8-ppc64le
+pumi,2.2.5,gcc@8.3.1,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,linux-rhel8-ppc64le
+pumi,2.2.5,gcc@9.1.0,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,linux-rhel8-ppc64le
+pumi,2.2.5,gcc@9.3.0,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,linux-rhel8-ppc64le
+pumi,2.2.5,gcc@10.2.0,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,linux-rhel8-ppc64le
+pumi,2.2.5,gcc@11.1.0,~fortran~int64~ipo~shared+simmodsuite_version_check~zoltan build_type=RelWithDebInfo simmodsuite=none,linux-rhel8-ppc64le
+py-certifi,2020.6.20,gcc@8.3.1,,linux-rhel8-ppc64le
+py-cython,0.29.22,gcc@8.3.1,,linux-rhel8-ppc64le
+py-docutils,0.15.2,gcc@8.3.1,,linux-rhel8-ppc64le
+py-mpi4py,3.0.3,gcc@8.3.1,,linux-rhel8-ppc64le
+py-numpy,1.20.3,gcc@8.3.1,+blas+lapack patches=873745d7b547857fcfec9cae90b09c133b42a4f0c23b6c2d84cf37e2dd816604,linux-rhel8-ppc64le
+py-pyelftools,0.26,gcc@8.3.1,,linux-rhel8-ppc64le
+py-pyelftools,0.26,gcc@9.1.0,,linux-rhel8-ppc64le
+py-pyelftools,0.26,gcc@9.3.0,,linux-rhel8-ppc64le
+py-pyelftools,0.26,gcc@10.2.0,,linux-rhel8-ppc64le
+py-pyelftools,0.26,gcc@11.1.0,,linux-rhel8-ppc64le
+py-pygments,2.6.1,gcc@8.3.1,,linux-rhel8-ppc64le
+py-setuptools,50.3.2,gcc@8.3.1,,linux-rhel8-ppc64le
+py-setuptools,50.3.2,gcc@8.3.1,,linux-rhel8-ppc64le
+py-setuptools,50.3.2,gcc@9.1.0,,linux-rhel8-ppc64le
+py-setuptools,50.3.2,gcc@9.3.0,,linux-rhel8-ppc64le
+py-setuptools,50.3.2,gcc@10.2.0,,linux-rhel8-ppc64le
+py-setuptools,50.3.2,gcc@11.1.0,,linux-rhel8-ppc64le
+py-toml,0.10.2,gcc@8.3.1,,linux-rhel8-ppc64le
+py-toml,0.10.2,gcc@9.1.0,,linux-rhel8-ppc64le
+py-toml,0.10.2,gcc@9.3.0,,linux-rhel8-ppc64le
+py-toml,0.10.2,gcc@10.2.0,,linux-rhel8-ppc64le
+py-toml,0.10.2,gcc@11.1.0,,linux-rhel8-ppc64le
+python,2.7.15,gcc@8.3.1,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=a8c52415a8b03c0e5f28b5d52ae498f7a7e602007db2b9554df28cd5685839b8,linux-rhel8-ppc64le
+python,3.7.7,gcc@8.3.1,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,linux-rhel8-ppc64le
+python,3.8.10,gcc@7.5.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,linux-rhel8-ppc64le
+python,3.8.10,gcc@8.3.1,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,linux-rhel8-ppc64le
+python,3.8.10,gcc@9.1.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,linux-rhel8-ppc64le
+python,3.8.10,gcc@9.3.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,linux-rhel8-ppc64le
+python,3.8.10,gcc@10.2.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,linux-rhel8-ppc64le
+python,3.8.10,gcc@11.1.0,+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,linux-rhel8-ppc64le
+python,3.8.10,gcc@8.3.1,+bz2+ctypes+dbm+debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,linux-rhel8-ppc64le
+qt,5.15.2,gcc@8.3.1,~dbus~debug~doc~examples~framework~gtk+gui~opengl~phonon+shared+sql+ssl+tools~webkit patches=75bcb4201fa3becdd205d393aee87afd9c792d0e1d736a49b2e000933664e051,7f34d48d2faaa108dc3fcc47187af1ccd1d37ee0f931b42597b820f03a99864c,linux-rhel8-ppc64le
+qthreads,1.14,gcc@8.3.1,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.14,gcc@9.1.0,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.14,gcc@9.3.0,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.14,gcc@10.2.0,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.14,gcc@8.3.1,+hwloc~spawn_cache+static scheduler=nemesis stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.14,gcc@9.1.0,+hwloc~spawn_cache+static scheduler=nemesis stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.14,gcc@9.3.0,+hwloc~spawn_cache+static scheduler=nemesis stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.14,gcc@10.2.0,+hwloc~spawn_cache+static scheduler=nemesis stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.16,gcc@8.3.1,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.16,gcc@9.1.0,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.16,gcc@9.3.0,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.16,gcc@10.2.0,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,linux-rhel8-ppc64le
+qthreads,1.16,gcc@11.1.0,+hwloc~spawn_cache+static scheduler=distrib stack_size=4096,linux-rhel8-ppc64le
+r,4.0.5,gcc@8.3.1,~X~external-lapack~memory_profiling~rmath,linux-rhel8-ppc64le
+raja,0.12.1,gcc@8.3.1,+cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+raja,0.12.1,gcc@9.1.0,+cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+raja,0.12.1,gcc@9.3.0,+cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+raja,0.12.1,gcc@10.2.0,+cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+raja,0.13.0,gcc@8.3.1,+cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+raja,0.13.0,gcc@9.1.0,+cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+raja,0.13.0,gcc@9.3.0,+cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+raja,0.13.0,gcc@10.2.0,+cuda+examples+exercises~ipo+openmp~rocm+shared~tests amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+rdma-core,system,gcc@7.5.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+rdma-core,system,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+rdma-core,system,gcc@9.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+rdma-core,system,gcc@9.3.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+rdma-core,system,gcc@10.2.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+rdma-core,system,gcc@11.1.0,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+readline,8.1,gcc@7.5.0,,linux-rhel8-ppc64le
+readline,8.1,gcc@8-os,,linux-rhel8-ppc64le
+readline,8.1,gcc@8.3.1,,linux-rhel8-ppc64le
+readline,8.1,gcc@9.1.0,,linux-rhel8-ppc64le
+readline,8.1,gcc@9.3.0,,linux-rhel8-ppc64le
+readline,8.1,gcc@10.2.0,,linux-rhel8-ppc64le
+readline,8.1,gcc@11.1.0,,linux-rhel8-ppc64le
+rempi,1.1.0,gcc@8.3.1,,linux-rhel8-ppc64le
+rempi,1.1.0,gcc@9.1.0,,linux-rhel8-ppc64le
+rempi,1.1.0,gcc@9.3.0,,linux-rhel8-ppc64le
+renderproto,0.11.1,gcc@8.3.1,,linux-rhel8-ppc64le
+scons,3.1.2,gcc@8.3.1,,linux-rhel8-ppc64le
+scorep,7.0,gcc@8.3.1,+mpi+papi~pdt~shmem~unwind,linux-rhel8-ppc64le
+screen,4.8.0,gcc@8.3.1, patches=755de623439b654453801dbbb09cce0f3f889a12ad1a060bf57147d5b2b5c295,linux-rhel8-ppc64le
+serf,1.3.9,gcc@8.3.1,~debug patches=b6593a4dafea97d1bef13b5d57fecb1410f02452d7def51b31f76bf76a85c4ad,linux-rhel8-ppc64le
+slate,2020.10.00,gcc@8.3.1,+cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+slate,2020.10.00,gcc@9.1.0,+cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+slate,2020.10.00,gcc@9.3.0,+cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+slate,2021.05.02,gcc@8.3.1,+cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+slate,2021.05.02,gcc@9.1.0,+cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+slate,2021.05.02,gcc@9.3.0,+cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+slate,2021.05.02,gcc@10.2.0,+cuda~ipo+mpi+openmp~rocm+shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+slepc,3.14.0,gcc@8.3.1,+arpack~blopex,linux-rhel8-ppc64le
+slepc,3.14.0,gcc@9.1.0,+arpack~blopex,linux-rhel8-ppc64le
+slepc,3.14.0,gcc@9.3.0,+arpack~blopex,linux-rhel8-ppc64le
+slepc,3.14.0,gcc@10.2.0,+arpack~blopex,linux-rhel8-ppc64le
+slepc,3.15.0,gcc@8.3.1,+arpack~blopex,linux-rhel8-ppc64le
+slepc,3.15.0,gcc@9.1.0,+arpack~blopex,linux-rhel8-ppc64le
+slepc,3.15.0,gcc@9.3.0,+arpack~blopex,linux-rhel8-ppc64le
+slepc,3.15.0,gcc@10.2.0,+arpack~blopex,linux-rhel8-ppc64le
+snappy,1.1.8,gcc@7.5.0,~ipo+pic+shared build_type=RelWithDebInfo patches=c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd,linux-rhel8-ppc64le
+snappy,1.1.8,gcc@8.3.1,~ipo+pic+shared build_type=RelWithDebInfo patches=c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd,linux-rhel8-ppc64le
+snappy,1.1.8,gcc@9.1.0,~ipo+pic+shared build_type=RelWithDebInfo patches=c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd,linux-rhel8-ppc64le
+snappy,1.1.8,gcc@9.3.0,~ipo+pic+shared build_type=RelWithDebInfo patches=c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd,linux-rhel8-ppc64le
+snappy,1.1.8,gcc@10.2.0,~ipo+pic+shared build_type=RelWithDebInfo patches=c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd,linux-rhel8-ppc64le
+snappy,1.1.8,gcc@11.1.0,~ipo+pic+shared build_type=RelWithDebInfo patches=c9cfecb1f7a623418590cf4e00ae7d308d1c3faeb15046c2e5090e38221da7cd,linux-rhel8-ppc64le
+spath,0.0.2,gcc@8.3.1,~ipo~mpi build_type=RelWithDebInfo,linux-rhel8-ppc64le
+spath,0.0.2,gcc@9.1.0,~ipo~mpi build_type=RelWithDebInfo,linux-rhel8-ppc64le
+spath,0.0.2,gcc@9.3.0,~ipo~mpi build_type=RelWithDebInfo,linux-rhel8-ppc64le
+spath,0.0.2,gcc@10.2.0,~ipo~mpi build_type=RelWithDebInfo,linux-rhel8-ppc64le
+spectral,20210514,gcc@8.3.1,~debug~examples~ipo~titan build_type=RelWithDebInfo prologue_dir=/sw/summit/spectral/usr/local,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,clang@10.0.1-0,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,clang@12.0.0-0,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,gcc@7.5.0,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,gcc@8.3.1,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,gcc@9.1.0,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,gcc@9.3.0,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,gcc@10.2.0,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,gcc@11.1.0,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,nvhpc@20.9,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,nvhpc@21.2,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,nvhpc@21.3,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,nvhpc@21.5,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,nvhpc@21.7,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,pgi@20.1,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,pgi@20.4,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,xl@16.1.1-beta103,,linux-rhel8-ppc64le
+spectrum-mpi,10.4.0.3-20210112,xl@16.1.1-10,,linux-rhel8-ppc64le
+sqlite,3.35.5,gcc@7.5.0,+column_metadata+fts~functions~rtree,linux-rhel8-ppc64le
+sqlite,3.35.5,gcc@8.3.1,+column_metadata+fts~functions~rtree,linux-rhel8-ppc64le
+sqlite,3.35.5,gcc@9.1.0,+column_metadata+fts~functions~rtree,linux-rhel8-ppc64le
+sqlite,3.35.5,gcc@9.3.0,+column_metadata+fts~functions~rtree,linux-rhel8-ppc64le
+sqlite,3.35.5,gcc@10.2.0,+column_metadata+fts~functions~rtree,linux-rhel8-ppc64le
+sqlite,3.35.5,gcc@11.1.0,+column_metadata+fts~functions~rtree,linux-rhel8-ppc64le
+stc,0.8.3,gcc@8.3.1,,linux-rhel8-ppc64le
+stc,0.8.3,gcc@9.1.0,,linux-rhel8-ppc64le
+stc,0.8.3,gcc@9.3.0,,linux-rhel8-ppc64le
+stc,0.8.3,gcc@10.2.0,,linux-rhel8-ppc64le
+stc,0.9.0,gcc@8.3.1,,linux-rhel8-ppc64le
+stc,0.9.0,gcc@9.1.0,,linux-rhel8-ppc64le
+stc,0.9.0,gcc@9.3.0,,linux-rhel8-ppc64le
+stc,0.9.0,gcc@10.2.0,,linux-rhel8-ppc64le
+stc,0.9.0,gcc@11.1.0,,linux-rhel8-ppc64le
+strumpack,5.0.0,gcc@8.3.1,~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+strumpack,5.0.0,gcc@9.1.0,~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+strumpack,5.0.0,gcc@9.3.0,~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+strumpack,5.0.0,gcc@10.2.0,~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+strumpack,5.1.1,gcc@8.3.1,~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+strumpack,5.1.1,gcc@9.1.0,~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+strumpack,5.1.1,gcc@9.3.0,~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+strumpack,5.1.1,gcc@10.2.0,~build_dev_tests~build_tests~butterflypack+c_interface~count_flops+cuda~ipo+mpi+openmp+parmetis~rocm~scotch~shared~slate~task_timers+zfp amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+subversion,1.14.0,gcc@8.3.1,~perl+serf,linux-rhel8-ppc64le
+suite-sparse,5.9.0,gcc@8.3.1,~cuda~openmp+pic~tbb,linux-rhel8-ppc64le
+suite-sparse,5.9.0,gcc@9.1.0,~cuda~openmp+pic~tbb,linux-rhel8-ppc64le
+suite-sparse,5.9.0,gcc@9.3.0,~cuda~openmp+pic~tbb,linux-rhel8-ppc64le
+suite-sparse,5.9.0,gcc@10.2.0,~cuda~openmp+pic~tbb,linux-rhel8-ppc64le
+sundials,5.4.0,gcc@8.3.1,+ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double,linux-rhel8-ppc64le
+sundials,5.4.0,gcc@9.1.0,+ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double,linux-rhel8-ppc64le
+sundials,5.4.0,gcc@9.3.0,+ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double,linux-rhel8-ppc64le
+sundials,5.4.0,gcc@10.2.0,+ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 precision=double,linux-rhel8-ppc64le
+sundials,5.7.0,gcc@8.3.1,+ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double,linux-rhel8-ppc64le
+sundials,5.7.0,gcc@9.1.0,+ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double,linux-rhel8-ppc64le
+sundials,5.7.0,gcc@9.3.0,+ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double,linux-rhel8-ppc64le
+sundials,5.7.0,gcc@10.2.0,+ARKODE+CVODE+CVODES+IDA+IDAS+KINSOL+cuda+examples+examples-install~f2003~fcmix+generic-math~hypre~int64~ipo~klu~lapack~monitoring+mpi~openmp~petsc~pthread~raja~rocm+shared+static~superlu-dist~superlu-mt~trilinos amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=8b29a47fac55346cdadfa133c51aa9314ae8c53ffdff5a8ecdc3dcea3ac26403 precision=double,linux-rhel8-ppc64le
+superlu,5.2.1,gcc@8.3.1,+pic,linux-rhel8-ppc64le
+superlu,5.2.1,gcc@9.1.0,+pic,linux-rhel8-ppc64le
+superlu,5.2.1,gcc@9.3.0,+pic,linux-rhel8-ppc64le
+superlu,5.2.1,gcc@10.2.0,+pic,linux-rhel8-ppc64le
+superlu,5.2.1,gcc@11.1.0,+pic,linux-rhel8-ppc64le
+superlu-dist,6.3.1,gcc@8.3.1,~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+superlu-dist,6.3.1,gcc@9.1.0,~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+superlu-dist,6.3.1,gcc@9.3.0,~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+superlu-dist,6.3.1,gcc@10.2.0,~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+superlu-dist,6.4.0,gcc@8.3.1,+cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+superlu-dist,6.4.0,gcc@9.1.0,+cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+superlu-dist,6.4.0,gcc@9.3.0,+cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+superlu-dist,6.4.0,gcc@10.2.0,+cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=70,linux-rhel8-ppc64le
+swig,4.0.2,gcc@8.3.1,,linux-rhel8-ppc64le
+swig,4.0.2,gcc@9.1.0,,linux-rhel8-ppc64le
+swig,4.0.2,gcc@9.3.0,,linux-rhel8-ppc64le
+swig,4.0.2,gcc@10.2.0,,linux-rhel8-ppc64le
+swig,4.0.2,gcc@11.1.0,,linux-rhel8-ppc64le
+swig,4.0.2-fortran,gcc@8.3.1,,linux-rhel8-ppc64le
+swig,4.0.2-fortran,gcc@9.1.0,,linux-rhel8-ppc64le
+swig,4.0.2-fortran,gcc@9.3.0,,linux-rhel8-ppc64le
+swig,4.0.2-fortran,gcc@10.2.0,,linux-rhel8-ppc64le
+swig,4.0.2-fortran,gcc@11.1.0,,linux-rhel8-ppc64le
+sz,1.4.12.3,gcc@8.3.1,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+sz,2.1.10,gcc@8.3.1,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+sz,2.1.10,gcc@9.1.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+sz,2.1.10,gcc@9.3.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+sz,2.1.10,gcc@10.2.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+sz,2.1.11.1,gcc@7.5.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+sz,2.1.11.1,gcc@8.3.1,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+sz,2.1.11.1,gcc@9.1.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+sz,2.1.11.1,gcc@9.3.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+sz,2.1.11.1,gcc@10.2.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+sz,2.1.11.1,gcc@11.1.0,~fortran~hdf5~ipo~netcdf~pastri~python~random_access+shared~stats~time_compression build_type=RelWithDebInfo,linux-rhel8-ppc64le
+tar,1.34,gcc@7.5.0,,linux-rhel8-ppc64le
+tar,1.34,gcc@8.3.1,,linux-rhel8-ppc64le
+tar,1.34,gcc@9.1.0,,linux-rhel8-ppc64le
+tar,1.34,gcc@9.3.0,,linux-rhel8-ppc64le
+tar,1.34,gcc@10.2.0,,linux-rhel8-ppc64le
+tar,1.34,gcc@11.1.0,,linux-rhel8-ppc64le
+tasmanian,7.3,gcc@8.3.1,~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+tasmanian,7.3,gcc@9.1.0,~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+tasmanian,7.3,gcc@9.3.0,~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+tasmanian,7.3,gcc@10.2.0,~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+tasmanian,7.5,gcc@8.3.1,~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+tasmanian,7.5,gcc@9.1.0,~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+tasmanian,7.5,gcc@9.3.0,~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+tasmanian,7.5,gcc@10.2.0,~blas+cuda~fortran~ipo~magma~mpi+openmp~python~rocm~xsdkflags amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+tau,2.29.1,gcc@8.3.1,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@9.1.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@9.3.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@10.2.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@8.3.1,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@9.1.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@9.3.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@10.2.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@8.3.1,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@9.1.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@9.3.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@10.2.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@8.3.1,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@9.1.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@9.3.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.29.1,gcc@10.2.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@8.3.1,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@9.1.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@9.3.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@10.2.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@8.3.1,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@9.1.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@9.3.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@10.2.0,~adios2+binutils~comm~craycnl~cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@8.3.1,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@9.1.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@9.3.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@10.2.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi~ompt~opari~opencl~openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@8.3.1,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@9.1.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@9.3.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tau,2.30.1,gcc@10.2.0,~adios2+binutils~comm~craycnl+cuda+elf+fortran~gasnet+io~level_zero+libdwarf+libunwind~likwid+mpi+ompt~opari~opencl+openmp+otf2+papi+pdt~phase~ppc64le~profileparam+pthreads~python~rocm~rocprofiler~scorep~shmem~sqlite~x86_64,linux-rhel8-ppc64le
+tcl,8.6.11,gcc@8.3.1,,linux-rhel8-ppc64le
+tcl,8.6.11,gcc@9.1.0,,linux-rhel8-ppc64le
+tcl,8.6.11,gcc@9.3.0,,linux-rhel8-ppc64le
+tcl,8.6.11,gcc@10.2.0,,linux-rhel8-ppc64le
+tcl,8.6.11,gcc@11.1.0,,linux-rhel8-ppc64le
+tcsh,6.22.02,gcc@8.3.1, patches=392615011adb7afeb0010152409a37b150f03dbde5b534503e9cd7363b742a19,3a4e60fe56a450632140c48acbf14d22850c1d72835bf441e3f8514d6c617a9f,linux-rhel8-ppc64le
+tcsh,6.22.02,gcc@9.1.0, patches=392615011adb7afeb0010152409a37b150f03dbde5b534503e9cd7363b742a19,3a4e60fe56a450632140c48acbf14d22850c1d72835bf441e3f8514d6c617a9f,linux-rhel8-ppc64le
+tcsh,6.22.02,gcc@9.3.0, patches=392615011adb7afeb0010152409a37b150f03dbde5b534503e9cd7363b742a19,3a4e60fe56a450632140c48acbf14d22850c1d72835bf441e3f8514d6c617a9f,linux-rhel8-ppc64le
+tcsh,6.22.02,gcc@10.2.0, patches=392615011adb7afeb0010152409a37b150f03dbde5b534503e9cd7363b742a19,3a4e60fe56a450632140c48acbf14d22850c1d72835bf441e3f8514d6c617a9f,linux-rhel8-ppc64le
+tcsh,6.22.02,gcc@11.1.0, patches=392615011adb7afeb0010152409a37b150f03dbde5b534503e9cd7363b742a19,3a4e60fe56a450632140c48acbf14d22850c1d72835bf441e3f8514d6c617a9f,linux-rhel8-ppc64le
+texinfo,6.5,gcc@8.3.1, patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1,linux-rhel8-ppc64le
+texinfo,6.5,gcc@9.1.0, patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1,linux-rhel8-ppc64le
+texinfo,6.5,gcc@9.3.0, patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1,linux-rhel8-ppc64le
+texinfo,6.5,gcc@10.2.0, patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1,linux-rhel8-ppc64le
+texinfo,6.5,gcc@11.1.0, patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1,linux-rhel8-ppc64le
+tmux,3.1b,gcc@8.3.1,,linux-rhel8-ppc64le
+trilinos,13.0.0,gcc@8.3.1,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long,linux-rhel8-ppc64le
+trilinos,13.0.0,gcc@9.1.0,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long,linux-rhel8-ppc64le
+trilinos,13.0.0,gcc@9.3.0,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long,linux-rhel8-ppc64le
+trilinos,13.0.0,gcc@10.2.0,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long,linux-rhel8-ppc64le
+trilinos,13.0.1,gcc@8.3.1,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long,linux-rhel8-ppc64le
+trilinos,13.0.1,gcc@9.1.0,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long,linux-rhel8-ppc64le
+trilinos,13.0.1,gcc@9.3.0,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long,linux-rhel8-ppc64le
+trilinos,13.0.1,gcc@10.2.0,~adios2~alloptpkgs+amesos+amesos2~amesos2basker+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~scorec~shards+shared~shylu~stk~stokhos~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long,linux-rhel8-ppc64le
+turbine,1.3.0,gcc@8.3.1,~hdf5~python~r,linux-rhel8-ppc64le
+turbine,1.3.0,gcc@9.1.0,~hdf5~python~r,linux-rhel8-ppc64le
+turbine,1.3.0,gcc@9.3.0,~hdf5~python~r,linux-rhel8-ppc64le
+turbine,1.3.0,gcc@10.2.0,~hdf5~python~r,linux-rhel8-ppc64le
+turbine,1.3.0,gcc@11.1.0,~hdf5~python~r,linux-rhel8-ppc64le
+udunits,2.2.28,gcc@8.3.1,,linux-rhel8-ppc64le
+udunits,2.2.28,gcc@9.1.0,,linux-rhel8-ppc64le
+udunits,2.2.28,gcc@9.3.0,,linux-rhel8-ppc64le
+umap,2.1.0,gcc@8.3.1,~ipo~logging~tests build_type=RelWithDebInfo,linux-rhel8-ppc64le
+umap,2.1.0,gcc@9.1.0,~ipo~logging~tests build_type=RelWithDebInfo,linux-rhel8-ppc64le
+umap,2.1.0,gcc@9.3.0,~ipo~logging~tests build_type=RelWithDebInfo,linux-rhel8-ppc64le
+umap,2.1.0,gcc@10.2.0,~ipo~logging~tests build_type=RelWithDebInfo,linux-rhel8-ppc64le
+umap,2.1.0,gcc@11.1.0,~ipo~logging~tests build_type=RelWithDebInfo,linux-rhel8-ppc64le
+umpire,4.0.1,gcc@8.3.1,+c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none,linux-rhel8-ppc64le
+umpire,4.0.1,gcc@9.1.0,+c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none,linux-rhel8-ppc64le
+umpire,4.0.1,gcc@9.3.0,+c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none,linux-rhel8-ppc64le
+umpire,4.0.1,gcc@10.2.0,+c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 tests=none,linux-rhel8-ppc64le
+umpire,4.1.2,gcc@8.3.1,+c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,linux-rhel8-ppc64le
+umpire,4.1.2,gcc@9.1.0,+c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,linux-rhel8-ppc64le
+umpire,4.1.2,gcc@9.3.0,+c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,linux-rhel8-ppc64le
+umpire,4.1.2,gcc@10.2.0,+c+cuda~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,linux-rhel8-ppc64le
+umpire,4.1.2,gcc@8.3.1,+c+cuda~deviceconst~examples~fortran~ipo~numa+openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,linux-rhel8-ppc64le
+umpire,4.1.2,gcc@9.1.0,+c+cuda~deviceconst~examples~fortran~ipo~numa+openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,linux-rhel8-ppc64le
+umpire,4.1.2,gcc@9.3.0,+c+cuda~deviceconst~examples~fortran~ipo~numa+openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,linux-rhel8-ppc64le
+umpire,4.1.2,gcc@10.2.0,+c+cuda~deviceconst~examples~fortran~ipo~numa+openmp~rocm~shared amdgpu_target=none build_type=RelWithDebInfo cuda_arch=70 patches=7d912d31cd293df005ba74cb96c6f3e32dc3d84afff49b14509714283693db08 tests=none,linux-rhel8-ppc64le
+unifyfs,0.9.2,gcc@8.3.1,+auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313,linux-rhel8-ppc64le
+unifyfs,0.9.2,gcc@9.1.0,+auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313,linux-rhel8-ppc64le
+unifyfs,0.9.2,gcc@9.3.0,+auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313,linux-rhel8-ppc64le
+unifyfs,0.9.2,gcc@10.2.0,+auto-mount~fortran~hdf5~pmi~pmix+spath patches=8a9c20c857c728637d994c097505cdce780f4b8e61535d221117864f75795313,linux-rhel8-ppc64le
+unzip,6.0,gcc@8.3.1,,linux-rhel8-ppc64le
+unzip,6.0,gcc@9.1.0,,linux-rhel8-ppc64le
+unzip,6.0,gcc@9.3.0,,linux-rhel8-ppc64le
+unzip,6.0,gcc@10.2.0,,linux-rhel8-ppc64le
+upcxx,2020.3.0,gcc@8.3.1,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2020.3.0,gcc@9.1.0,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2020.3.0,gcc@9.3.0,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2020.3.0,gcc@10.2.0,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2020.10.0,gcc@8.3.1,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2020.10.0,gcc@9.1.0,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2020.10.0,gcc@9.3.0,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2020.10.0,gcc@10.2.0,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2021.3.0,gcc@8.3.1,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2021.3.0,gcc@9.1.0,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2021.3.0,gcc@9.3.0,+cuda~mpi cross=none,linux-rhel8-ppc64le
+upcxx,2021.3.0,gcc@10.2.0,+cuda~mpi cross=none,linux-rhel8-ppc64le
+utf8proc,2.4.0,gcc@8.3.1,~ipo build_type=RelWithDebInfo,linux-rhel8-ppc64le
+util-linux-uuid,2.36.2,gcc@7.5.0,,linux-rhel8-ppc64le
+util-linux-uuid,2.36.2,gcc@8.3.1,,linux-rhel8-ppc64le
+util-linux-uuid,2.36.2,gcc@9.1.0,,linux-rhel8-ppc64le
+util-linux-uuid,2.36.2,gcc@9.3.0,,linux-rhel8-ppc64le
+util-linux-uuid,2.36.2,gcc@10.2.0,,linux-rhel8-ppc64le
+util-linux-uuid,2.36.2,gcc@11.1.0,,linux-rhel8-ppc64le
+util-macros,1.19.1,gcc@8.3.1,,linux-rhel8-ppc64le
+util-macros,1.19.1,gcc@9.1.0,,linux-rhel8-ppc64le
+util-macros,1.19.1,gcc@9.3.0,,linux-rhel8-ppc64le
+util-macros,1.19.1,gcc@10.2.0,,linux-rhel8-ppc64le
+util-macros,1.19.1,gcc@11.1.0,,linux-rhel8-ppc64le
+valgrind,3.17.0,gcc@8.3.1,~boost~mpi+only64bit~ubsan,linux-rhel8-ppc64le
+valgrind,3.17.0,gcc@8.3.1,+boost+mpi+only64bit~ubsan,linux-rhel8-ppc64le
+vim,8.2.2541,gcc@8.3.1,~big~cscope~gui~huge~lua~normal~perl~python~ruby~small~tiny~x,linux-rhel8-ppc64le
+vtk-h,0.7.1,gcc@8.3.1,~contourtree~cuda~logging+mpi+openmp+serial+shared cuda_arch=none,linux-rhel8-ppc64le
+vtk-h,0.7.1,gcc@9.1.0,~contourtree~cuda~logging+mpi+openmp+serial+shared cuda_arch=none,linux-rhel8-ppc64le
+vtk-h,0.7.1,gcc@9.3.0,~contourtree~cuda~logging+mpi+openmp+serial+shared cuda_arch=none,linux-rhel8-ppc64le
+vtk-m,1.5.5,gcc@8.3.1,~64bitids+ascent_types~cuda+doubleprecision~hip~ipo~logging~mpi+openmp+rendering~shared~tbb~virtuals amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+vtk-m,1.5.5,gcc@9.1.0,~64bitids+ascent_types~cuda+doubleprecision~hip~ipo~logging~mpi+openmp+rendering~shared~tbb~virtuals amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+vtk-m,1.5.5,gcc@9.3.0,~64bitids+ascent_types~cuda+doubleprecision~hip~ipo~logging~mpi+openmp+rendering~shared~tbb~virtuals amdgpu_target=none build_type=Release cuda_arch=none,linux-rhel8-ppc64le
+xcb-proto,1.14.1,gcc@8.3.1,,linux-rhel8-ppc64le
+xcb-util,0.4.0,gcc@8.3.1,,linux-rhel8-ppc64le
+xcb-util-image,0.4.0,gcc@8.3.1,,linux-rhel8-ppc64le
+xcb-util-keysyms,0.4.0,gcc@8.3.1,,linux-rhel8-ppc64le
+xcb-util-renderutil,0.3.9,gcc@8.3.1,,linux-rhel8-ppc64le
+xcb-util-wm,0.4.1,gcc@8.3.1,,linux-rhel8-ppc64le
+xerces-c,3.2.3,gcc@8.3.1, cxxstd=default netaccessor=curl transcoder=iconv,linux-rhel8-ppc64le
+xerces-c,3.2.3,gcc@9.1.0, cxxstd=default netaccessor=curl transcoder=iconv,linux-rhel8-ppc64le
+xerces-c,3.2.3,gcc@9.3.0, cxxstd=default netaccessor=curl transcoder=iconv,linux-rhel8-ppc64le
+xerces-c,3.2.3,gcc@10.2.0, cxxstd=default netaccessor=curl transcoder=iconv,linux-rhel8-ppc64le
+xextproto,7.3.0,gcc@8.3.1,,linux-rhel8-ppc64le
+xkbcomp,1.4.4,gcc@8.3.1,,linux-rhel8-ppc64le
+xkbdata,1.0.1,gcc@8.3.1,,linux-rhel8-ppc64le
+xproto,7.0.31,gcc@8.3.1,,linux-rhel8-ppc64le
+xtrans,1.3.5,gcc@8.3.1,,linux-rhel8-ppc64le
+xz,5.2.5,gcc@7.5.0,~pic libs=shared,static,linux-rhel8-ppc64le
+xz,5.2.5,gcc@8.3.1,~pic libs=shared,static,linux-rhel8-ppc64le
+xz,5.2.5,gcc@9.1.0,~pic libs=shared,static,linux-rhel8-ppc64le
+xz,5.2.5,gcc@9.3.0,~pic libs=shared,static,linux-rhel8-ppc64le
+xz,5.2.5,gcc@10.2.0,~pic libs=shared,static,linux-rhel8-ppc64le
+xz,5.2.5,gcc@11.1.0,~pic libs=shared,static,linux-rhel8-ppc64le
+xz,5.2.5,gcc@8.3.1,+pic libs=shared,static,linux-rhel8-ppc64le
+xz,5.2.5,gcc@9.1.0,+pic libs=shared,static,linux-rhel8-ppc64le
+xz,5.2.5,gcc@9.3.0,+pic libs=shared,static,linux-rhel8-ppc64le
+xz,5.2.5,gcc@10.2.0,+pic libs=shared,static,linux-rhel8-ppc64le
+zfp,0.5.5,gcc@7.5.0,~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=64 build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+zfp,0.5.5,gcc@8.3.1,~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=64 build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+zfp,0.5.5,gcc@9.1.0,~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=64 build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+zfp,0.5.5,gcc@9.3.0,~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=64 build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+zfp,0.5.5,gcc@10.2.0,~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=64 build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+zfp,0.5.5,gcc@11.1.0,~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=64 build_type=RelWithDebInfo cuda_arch=none,linux-rhel8-ppc64le
+zlib,1.2.11,gcc@7.5.0,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,gcc@8.3.1,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,gcc@9.1.0,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,gcc@9.3.0,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,gcc@10.2.0,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,gcc@11.1.0,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,nvhpc@20.9,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,nvhpc@21.2,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,nvhpc@21.3,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,nvhpc@21.5,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,nvhpc@21.7,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,pgi@20.1,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,pgi@20.4,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,xl@16.1.1-beta103,+optimize+pic+shared,linux-rhel8-ppc64le
+zlib,1.2.11,xl@16.1.1-10,+optimize+pic+shared,linux-rhel8-ppc64le
+zsh,5.8,gcc@8.3.1,+skip-tcsetpgrp-test,linux-rhel8-ppc64le
+zsh,5.8,gcc@9.1.0,+skip-tcsetpgrp-test,linux-rhel8-ppc64le
+zsh,5.8,gcc@9.3.0,+skip-tcsetpgrp-test,linux-rhel8-ppc64le
+zsh,5.8,gcc@10.2.0,+skip-tcsetpgrp-test,linux-rhel8-ppc64le
+zsh,5.8,gcc@11.1.0,+skip-tcsetpgrp-test,linux-rhel8-ppc64le
+zstd,1.5.0,gcc@7.5.0,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,linux-rhel8-ppc64le
+zstd,1.5.0,gcc@8.3.1,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,linux-rhel8-ppc64le
+zstd,1.5.0,gcc@9.1.0,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,linux-rhel8-ppc64le
+zstd,1.5.0,gcc@9.3.0,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,linux-rhel8-ppc64le
+zstd,1.5.0,gcc@10.2.0,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,linux-rhel8-ppc64le
+zstd,1.5.0,gcc@11.1.0,~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo,linux-rhel8-ppc64le

--- a/OLCF/summit/spack.yaml
+++ b/OLCF/summit/spack.yaml
@@ -1,0 +1,1439 @@
+# OLCF Summit Spack Environment
+
+spack:
+  #############################################################################
+  definitions:
+  - core_compiler:
+    - '%gcc@8.3.1'
+  - gcc_compilers:
+    - '%gcc@7.5.0'
+    - '%gcc@8.3.1'
+    - '%gcc@9.1.0'
+    - '%gcc@9.3.0'
+    - '%gcc@10.2.0'
+    - '%gcc@11.1.0'
+  - xl_compilers:
+    - '%xl@16.1.1-10'
+    - '%xl@16.1.1-beta103'
+  - llvm_compilers:
+    - '%clang@12.0.0-0'
+    - '%clang@10.0.1-0'
+  - nv_compilers:
+    - '%nvhpc@21.7'
+    - '%nvhpc@21.5'
+    - '%nvhpc@21.3'
+    - '%nvhpc@21.2'
+    - '%nvhpc@20.9'
+    - '%pgi@20.4'
+    - '%pgi@20.1'
+  - all_compilers:
+    - $gcc_compilers
+    - $xl_compilers
+    - $llvm_compilers
+    - $nv_compilers
+  - core_packages:
+    - git
+    - htop
+    - tmux
+    - cmake
+    - go
+    - screen
+    - vim
+    - emacs ~X
+    - nano
+    - gnuplot
+    - subversion
+    - darshan-util
+    - python@2.7.15
+    - python@3.7.7
+    - mercurial
+    - gnuplot@5.0.1
+    - libevent@2.1.8 +openssl
+    - valgrind ~ubsan~mpi~boost
+    - ccache
+    - papi~cuda
+    - gdb
+    - libzmq
+    - gnupg
+    - gsl
+    - nco~mpi-deps
+    - libfabric
+    - libfabric ^rdma-core@system
+    - git-lfs
+    - patchelf
+    - libzmq
+    - makedepend
+    - r@4.0.5
+    - julia+cxx
+    - hpcviewer@2021.03
+    - cube@4.6+gui
+    - googletest
+    - imagemagick
+  - core_only_compute_packages:
+    - darshan-runtime@3.2.1~hdf5
+    - darshan-runtime@3.2.1+hdf5
+    - darshan-runtime@3.3.0~hdf5
+    - darshan-runtime@3.3.0+hdf5
+    - scorep@7.0+mpi+papi
+    - valgrind ~ubsan+mpi+boost
+    - adios2 +python ^python@3.7.7
+    - adios@1.13.1+blosc+bzip2+fortran+hdf5+infiniband+netcdf
+    - gdrcopy
+    - gromacs        +hwloc+cuda+mpi ^cuda@10.2.89
+    - gromacs        +hwloc+cuda~mpi ^cuda@10.2.89
+    - gromacs@2020.4 +hwloc+cuda+mpi ^cuda@10.2.89
+    - gromacs@2020.4 +hwloc+cuda~mpi ^cuda@10.2.89
+    - gromacs@2020.2 +hwloc+cuda+mpi ^cuda@10.2.89
+    - gromacs@2020.2 +hwloc+cuda~mpi ^cuda@10.2.89
+  - general_compute_packages:
+    - netlib-lapack
+    - netlib-scalapack
+    - fftw +mpi+openmp
+    - hdf5 ~mpi
+    - hdf5 +mpi
+    - boost ~mpi
+    - boost +mpi
+    - netcdf-c
+    - netcdf-fortran
+    - netcdf-cxx4~doxygen
+    - parallel-netcdf
+    - parallel-io
+    - hypre
+    - mpip
+    - adios2 ~python
+  - e4s_20.10_packages:
+    # - adios@1.13.1         ## rejected by site
+    - adios2@2.7.1~python    ## changed from v2.6.0 due to broken patch
+    - aml@0.1.0
+    # - arborx@0.9-beta      ## Missing kokkos CUDA_LAMBDA
+    # - axom@0.3.3           ## build system errors (bad fc id)
+    - bolt@1.0
+    - caliper@2.4.0~libdw
+    # - darshan-runtime@3.2.1 ## installed globally
+    # - darshan-util@3.2.1    ## installed globally
+    - dyninst@10.2.1
+    - faodel@1.1906.1~tcmalloc
+    # - flecsi@1+cinch        ## build fail
+    - flit@2.1.0
+    - gasnet@2020.3.0
+    - ginkgo@1.3.0
+    - globalarrays@5.7
+    - gotcha@1.0.3
+    - hdf5@1.10.6+mpi
+    - hpctoolkit@2020.08.03
+    - hpx@1.5.1 # FIXME: +cuda?
+    - hypre@2.20.0
+    - kokkos-kernels@3.2.00
+    - kokkos+openmp@3.2.00
+    - legion@20.03.0+cuda+hdf5 cuda_arch=70
+    # - libnrm@0.1.0         ## mpich unavailable
+    - libquo@1.3.1
+    - magma@2.5.4
+    - mercury@1.0.1
+    # - mfem@4.1.0           ## build fail
+    - mpifileutils@0.10.1
+    - ninja@1.10.1
+    # - omega-h@9.29.0       ## code bugs
+    # - openmpi@3.1.6        ## rejected by site
+    - openpmd-api@0.12.0
+    - papi@6.0.0.1
+    - papyrus@1.0.0
+    - parallel-netcdf@1.12.1
+    - pdt@3.25.1
+    - petsc@3.14.0+cuda
+    # - phist@1.9.1          ## build system bugs (-march vs -mcpu)
+    - plasma@20.9.20
+    - pumi@2.2.2
+    # - py-jupyterhub@1.0.0  ## rejected by site
+    # - py-libensemble@0.7.1 ## rejected by site
+    # - py-petsc4py@3.13.0   ## rejected by site
+    - qthreads@1.14
+    - raja@0.12.1
+    - rempi@1.1.0
+    # - scr@2.0.0            ## slurm unavailable
+    - slepc@3.14.0
+    - stc@0.8.3            ## conflict: ppc64le
+    - strumpack@5.0.0~slate
+    - sundials@5.4.0
+    - superlu-dist@6.3.1~cuda cuda_arch=none
+    - superlu@5.2.1
+    - swig@4.0.2
+    - sz@2.1.10
+    - tasmanian@7.3
+    - tau@2.29.1~cuda+mpi~ompt~openmp ^papi~cuda
+    - tau@2.29.1~cuda+mpi+ompt+openmp ^papi~cuda
+    - tau@2.29.1+cuda+mpi~ompt~openmp
+    - tau@2.29.1+cuda+mpi+ompt+openmp
+    - trilinos@13.0.0
+    # - turbine@1.2.3
+    - umap@2.1.0
+    - umpire@4.0.1
+    - unifyfs@0.9.2
+    - upcxx@2020.3.0
+    # - veloc@1.4            ## Code issue; `include/axl.h: int AXL_Create called with wrong signature (too many args)`
+    - zfp@0.5.5
+  - e4s_21.02_packages:
+    # - adios@1.13.1         ## rejected by site
+    - adios2@2.7.1~python
+    - aml@0.1.0
+    - amrex@21.02
+    # - arborx@0.9-beta      ## Missing kokkos CUDA_LAMBDA
+    # - axom@0.4.0           ## FIXME: conduit dependency's ConduitConfig.cmake in wrong place `lib/cmake/conduit/ConduitConfig.cmake`
+    - bolt@2.0
+    - caliper@2.5.0
+    # - darshan-runtime@3.2.1 ## installed globally
+    # - darshan-util@3.2.1    ## installed globally
+    - dyninst@10.2.1
+    - faodel@1.1906.1~tcmalloc
+    - flecsi@1.4+cinch
+    - flit@2.1.0
+    - gasnet@2020.3.0
+    - ginkgo@1.3.0
+    - globalarrays@5.8
+    - gotcha@1.0.3
+    - hdf5@1.10.7+mpi
+    - hpctoolkit@2020.08.03
+    - hpx@1.6.0 # FIXME: +cuda?
+    - hypre@2.20.0
+    - kokkos-kernels@3.2.00
+    - kokkos+openmp@3.2.00
+    - legion@20.03.0+cuda+hdf5 cuda_arch=70
+    # - libnrm@0.1.0         ## mpich unavailable
+    - libquo@1.3.1
+    - magma@2.5.4
+    - mercury@2.0.0
+    # - mfem@4.2.0           ## build fail
+    - mpifileutils@0.10.1
+    - ninja@1.10.2
+    - omega-h@9.32.5
+    # - openmpi@3.1.6        ## rejected by site
+    - openpmd-api@0.13.2
+    - papi@6.0.0.1
+    - papyrus@1.0.1
+    - parallel-netcdf@1.12.1
+    - pdt@3.25.1
+    - petsc@3.14.4+cuda
+    # - phist@1.9.3
+    - plasma@20.9.20
+    - precice@2.2.0
+    - pumi@2.2.5
+    # - py-jupyterhub@1.0.0  ## rejected by site
+    # - py-libensemble@0.7.1 ## rejected by site
+    # - py-petsc4py@3.13.0   ## rejected by site
+    - qthreads@1.14 scheduler=distrib
+    - raja@0.13.0
+    - rempi@1.1.0
+    # - scr@2.0.0            ## slurm unavailable
+    - slepc@3.14.0
+    - slate@2020.10.00+cuda cuda_arch=70 ^openblas@0.3.5 threads=openmp ^blaspp+cuda cuda_arch=70
+    - stc@0.8.3            ## conflict: ppc64le
+    - strumpack@5.1.1 ~slate ^openblas threads=openmp
+    - sundials@5.7.0
+    - superlu-dist@6.4.0+cuda cuda_arch=70
+    - superlu@5.2.1
+    - swig@4.0.2-fortran
+    - sz@2.1.11.1
+    - tasmanian@7.3
+    - tau@2.30.1~cuda+mpi~ompt~openmp ^papi~cuda
+    - tau@2.30.1~cuda+mpi+ompt+openmp ^papi~cuda
+    - tau@2.30.1+cuda+mpi~ompt~openmp
+    - tau@2.30.1+cuda+mpi+ompt+openmp
+    - trilinos@13.0.1
+    # - turbine@1.2.3
+    - umap@2.1.0
+    - umpire@4.1.2
+    - unifyfs@0.9.2
+    - upcxx@2020.10.0
+    # - veloc@1.4
+    - zfp@0.5.5
+  - e4s_21.05_packages:
+    # - adios@1.13.1 ## rejected by site
+    - adios2@2.7.1~python
+    - aml@0.1.0
+    - amrex@21.05
+    - arborx@1.0+cuda
+    # - archer@2.0.0
+    - argobots@1.1
+    - ascent@0.7.1
+    - axom@0.5.0
+    - bolt@2.0
+    - cabana@0.3.0+cuda
+    - caliper@2.5.0
+    - chai@2.3.0~benchmarks+cuda cuda_arch=70
+    - conduit@0.7.2
+    # - darshan-runtime@3.3.0 ## installed globally
+    # - darshan-util@3.3.0    ## installed globally
+    - dyninst@11.0.0
+    - faodel@1.1906.1~tcmalloc
+    - flecsi@1.4+cinch
+    - flit@2.1.0
+    - gasnet@2020.3.0
+    - ginkgo@1.3.0
+    - globalarrays@5.8
+    - gmp@6.2.1
+    - gotcha@1.0.3
+    - hdf5@1.10.7+mpi
+    - heffte@2.0.0+fftw
+    - hpctoolkit@2021.03.01
+    - hpx@1.6.0
+    - hypre@2.20.0
+    - kokkos-kernels@3.2.00
+    - kokkos@3.4.00 +openmp
+    - legion@21.03.0+cuda+hdf5 cuda_arch=70
+    # - libnrm@0.1.0 ## hard mpich dependency
+    - libquo@1.3.1
+    - magma@2.6.1
+    - mercury@2.0.1
+    # - mfem@4.2.0 ## build fail
+    - mpifileutils@0.11
+    - ninja@1.10.2
+    - omega-h@9.32.5
+    # - openmpi@t4.0.5 ## rejected by site
+    - openpmd-api@0.13.4
+    - papi@6.0.0.1
+    - papyrus@1.0.1
+    - parallel-netcdf@1.12.2
+    - pdt@3.25.1
+    - petsc@3.15.0+cuda
+    # - phist@1.9.3
+    - plasma@20.9.20
+    - precice@2.2.1
+    - pumi@2.2.5
+    # - py-jupyterhub@1.0.0 ## rejected by site
+    # - py-libensemble@0.7.1 ## rejected by site
+    # - py-petsc4py@3.13.0 ## rejected by site
+    - qthreads@1.16 scheduler=distrib
+    - raja@0.13.0
+    - rempi@1.1.0
+    # - scr@3.0rc1 ## slurm unavailable
+    - slate@2021.05.02 +cuda cuda_arch=70 ^openblas@0.3.5 threads=openmp ^blaspp+cuda cuda_arch=70
+    - slepc@3.15.0
+    - stc@0.9.0
+    - strumpack@5.1.1 ~slate ^openblas threads=openmp
+    - sundials@5.7.0
+    - superlu-dist@6.4.0+cuda cuda_arch=70
+    - superlu@5.2.1
+    - swig@4.0.2
+    - swig@4.0.2-fortran
+    - sz@2.1.11.1
+    - tasmanian@7.5
+    - tau@2.30.1~cuda+mpi~ompt~openmp ^papi~cuda
+    - tau@2.30.1~cuda+mpi+ompt+openmp ^papi~cuda
+    - tau@2.30.1+cuda+mpi~ompt~openmp
+    - tau@2.30.1+cuda+mpi+ompt+openmp
+    - trilinos@13.0.1
+    - turbine@1.3.0
+    - umap@2.1.0
+    - umpire@4.1.2
+    - unifyfs@0.9.2
+    - upcxx@2021.3.0
+    - zfp@0.5.5
+  - core_specs:
+    - matrix:
+      - - $core_packages
+      - - $core_compiler
+  - smpi_specs:
+    - matrix:
+      - - spectrum-mpi
+      - - $all_compilers
+  - core_compute_specs:
+    - matrix:
+      - - $core_only_compute_packages
+        - spectral@20210514
+      - - $core_compiler
+  - gcc_specs:
+    - matrix:
+      - - openblas threads=openmp
+        - openblas threads=none
+        - netlib-scalapack ^openblas threads=openmp
+      - - '%gcc@9.3.0'
+    - matrix:
+      - - $general_compute_packages
+        - nco
+        - $e4s_20.10_packages
+        - $e4s_21.02_packages
+        - $e4s_21.05_packages
+      - - '%gcc@8.3.1'
+        - '%gcc@9.1.0'
+        - '%gcc@9.3.0'
+      - - ^cuda@11.0.3
+    - matrix:
+      - - $general_compute_packages
+      - - '%gcc@7.5.0'
+      - - ^cuda@11.0.3
+    - matrix:
+      - - $general_compute_packages
+        - $e4s_20.10_packages
+        - $e4s_21.02_packages
+        - $e4s_21.05_packages
+      - - '%gcc@10.2.0'
+      - - ^cuda@11.1.1
+      exclude:
+      - ascent@0.7.1%gcc@10.2.0   # examples fail with argument mismatch
+      - globalarrays%gcc@10.2.0   # conflict in package
+      - rempi@1.1.0%gcc@10.2.0    # code error
+      - mercury@1.0.1%gcc@10.2.0  # code error
+      - slate@2020.10.00%gcc@10.2.0 # broken custom ICL BLASFinder.cmake macro >:(
+    - matrix:
+      - - $general_compute_packages
+        - $e4s_21.05_packages
+      - - '%gcc@11.1.0'
+      exclude:
+      - conduit
+      - faodel
+      - globalarrays
+      - omega-h
+      - trilinos
+      - unifyfs
+      - ascent@0.7.1 # examples fail with argument mismatch
+      - rempi@1.1.0  # code error
+      - mercury@1.0.1  # code error
+      - zfp+cuda # FIXME: possibly make zfp+cuda the default?
+      - amrex+cuda # FIXME: make amrex+cuda the default
+      - arborx+cuda
+      - axom~cuda # FIXME: depends on raja+cuda
+      - axom+cuda # FIXME: make axom+cuda the default
+      - cabana+cuda
+      - caliper~cuda # FIXME: depends on papi+cuda
+      - caliper+cuda # FIXME: make caliper+cuda the default
+      - chai+cuda
+      - ginkgo+cuda # FIXME: make ginkgo+cuda the default
+      - heffte+cuda # FIXME: make heffte+cuda the default
+      - hpctoolkit+cuda
+      - hpx+cuda # FIXME: make hpx+cuda the default
+      - kokkos-kernels+cuda
+      - kokkos+cuda
+      - legion+cuda
+      - magma+cuda
+      - papi+cuda
+      - petsc+cuda
+      - precice # FIXME: could be made w/o ^superlu-dist+cuda
+      - raja+cuda
+      - slepc # FIXME: could be made w/o ^superlu-dist+cuda
+      - strumpack+cuda
+      - sundials+cuda
+      - superlu-dist+cuda
+      - slate+cuda
+      - tasmanian+cuda
+      - tau~cuda+mpi~ompt~openmp ^papi~cuda
+      - tau~cuda+mpi+ompt+openmp ^papi~cuda
+      - tau+cuda+mpi~ompt~openmp
+      - tau+cuda+mpi+ompt+openmp
+      - umpire+cuda
+      - upcxx+cuda
+      - slate@2020.10.00 # broken custom ICL BLASFinder.cmake macro >:(
+    - kokkos%gcc@8.3.1+wrapper+openmp std=14 +cuda cuda_arch=70 ^cuda@11.0.3
+    - magma@2.5.3%gcc@8.3.1 ^cuda@10.2.89
+    - amgx%gcc@8.3.1 +cuda cuda_arch=70 ^cuda@10.2.89
+    - hpx %gcc@8.3.1 cxxstd=14 ^boost@1.70.0:1.72.0 # FIXME: +cuda?
+    - hpx %gcc@8.3.1 cxxstd=17 ^boost@1.70.0:1.72.0 # FIXME: +cuda?
+  - llvm_specs:
+    - matrix:
+      - - $general_compute_packages
+        - $e4s_21.02_packages
+        - $e4s_21.05_packages
+        - trilinos@13.0.0+intrepid2+shards~muelu
+      - - $llvm_compilers
+      exclude:
+      - mpip   # ^elfutils !conflicts clang
+      - dyninst   # ^elfutils !conflicts clang
+      - hpctoolkit   # ^elfutils !conflicts clang
+      - caliper # ^elfutils !conflicts clang
+      - strumpack
+      - plasma
+      - ^elfutils
+      - tau
+      - trilinos+intrepid2+shards+muelu
+  - xl_specs:
+    # FIXME: Pin netlib-lapack to v3.8.0 for XL.
+    - matrix:
+      - - netlib-lapack@3.8.0
+      - - $xl_compilers
+      - - ^cmake%gcc@8-os
+    - matrix:
+      - - $general_compute_packages
+        - parallel-io@2.3.0
+        - boost@1.62.0 ~mpi
+        - boost@1.62.0 +mpi
+        - adios2~python+zpf
+      - - $xl_compilers
+      - - ^netlib-lapack@3.8.0
+      - - ^numactl%gcc@8-os
+      - - ^libfabric%gcc@8-os
+      - - ^libzmq%gcc@8-os
+      - - ^cmake%gcc@8-os
+      - - ^automake%gcc@8-os
+      - - ^autoconf%gcc@8-os
+      - - ^m4%gcc@8-os
+      - - ^perl%gcc@8-os
+      - - ^pkgconf%gcc@8-os
+      exclude:
+      - boost@1.63.0:%xl
+      - 'parallel-io@2.4.4:'
+      - mpip
+      - adios2+zpf
+      - netlib-lapack
+    # - matrix:
+    #   - - netlib-lapack
+    #   - - $xl_compilers
+    #   - - ^cmake%gcc@8-os
+  - nv_specs:
+    - matrix:
+      - - $general_compute_packages
+        - globalarrays
+      - - $nv_compilers
+      - - ^cmake%gcc@8-os
+      - - ^python%gcc@8-os
+      - - ^numactl%gcc@8-os
+      - - ^perl%gcc@8-os
+      - - ^automake%gcc@8-os
+      - - ^autoconf%gcc@8-os
+      - - ^m4%gcc@8-os
+      exclude:
+      - adios2%nvhpc
+      - mpip%nvhpc
+      - boost%nvhpc
+      - netlib-scalapack%nvhpc
+      - fftw@3.3.9:%pgi
+      - adios2%pgi
+      - mpip%pgi
+      - boost%pgi
+      - netlib-scalapack%pgi@20.1
+    - magma@2.6.1%nvhpc@21.7 ^cmake%gcc@8-os ^cuda@11.0.3
+  - special_builds:
+    ## Cannot build do to error in ompi configure finding liblsf/ls_info.
+    ## FIXME - ompi version needs to be checked
+    - openmpi@4.0.3%gcc@8.3.1+cuda+legacylaunchers+pmi+thread_multiple fabrics=ucx,hcoll,knem
+      schedulers=lsf ^ucx+cuda+gdrcopy cuda_arch=70
+  specs:
+  - pgi@20.4%gcc@8-os +mpi+mpigpu+managed+nvidia+single~network
+  - pgi@20.1%gcc@8-os +mpi+mpigpu+managed+nvidia+single~network
+  - $core_specs
+  - $smpi_specs
+  - $core_compute_specs
+  - $gcc_specs
+  - $llvm_specs
+  - $xl_specs
+  - $nv_specs
+  ## - $special_builds ## See note in definition section.
+  # - py-pip%gcc@8.3.1 ^/ethjbxn
+  # - py-pip%gcc@8.3.1 ^/eltc6cg
+  #############################################################################
+  mirrors:
+    facility_builds: /sw/summit/spack-envs/mirrors/builds
+  repos:
+  - ${FACSPACK_CONF_COMMON}/spack/repos/olcf
+  #############################################################################
+  packages:
+    spectrum-mpi:
+      version:
+      - 10.4.0.3-20210112
+      - 10.4.0.0-20200604
+      - 10.3.1.2-20200121
+      target: []
+      compiler: []
+      buildable: true
+      providers: {}
+    cuda:
+      buildable: false
+      version:
+      - 11.0.3
+      - 11.1.1
+      - 11.0.2
+      - 10.2.89
+      - 10.1.243
+      - 10.1.168
+      externals:
+      - spec: cuda@11.1.1
+        modules:
+        - cuda/11.1.1
+      - spec: cuda@11.0.3
+        modules:
+        - cuda/11.0.3
+      - spec: cuda@11.0.2
+        modules:
+        - cuda/11.0.2
+      - spec: cuda@10.2.89
+        modules:
+        - cuda/10.2.89
+      - spec: cuda@10.1.243
+        modules:
+        - cuda/10.1.243
+      - spec: cuda@10.1.168
+        modules:
+        - cuda/10.1.168
+      target: []
+      providers: {}
+      compiler: []
+    rdma-core:
+      buildable: true
+      version: [system]
+      externals:
+      - spec: rdma-core@system
+        prefix: /usr
+    amgx:
+      variants: +cuda cuda_arch=70
+      version: []
+      target: []
+      compiler: []
+      buildable: true
+      providers: {}
+    lsf:
+      version: [10.1.0.10]
+      buildable: false
+      externals:
+      - spec: lsf@10.1.0.10
+        prefix: /opt/ibm/spectrumcomputing/lsf/10.1.0.10
+      target: []
+      compiler: []
+      providers: {}
+    hcoll:
+      buildable: false
+      version: [4.4]
+      externals:
+      - spec: hcoll@4.4
+        prefix: /opt/mellanox/hcoll
+      target: []
+      compiler: []
+      providers: {}
+    libfabric:
+      variants: fabrics=verbs,rxm,sockets,tcp,udp
+    knem:
+      buildable: false
+      version: [1.1.3]
+      externals:
+      - spec: knem@1.1.3
+        prefix: /opt/knem-1.1.3.90mlnx1
+      target: []
+      compiler: []
+      providers: {}
+    go-bootstrap:
+      buildable: false
+      version: [1.7.1-bootstrap]
+      externals:
+      - spec: go-bootstrap@1.7.1-bootstrap
+        prefix: /sw/summit/go/1.7.1-bootstrap
+      target: []
+      providers: {}
+      compiler: []
+    gtkplus:
+      version: [3.22.30, 2.24.32]
+      buildable: false
+      externals:
+      - spec: gtkplus@2.24.32
+        prefix: /usr
+      - spec: gtkplus@3.22.30
+        prefix: /usr
+      target: []
+      providers: {}
+      compiler: []
+    openssl:
+      buildable: false
+      version: [1.1.1]
+      externals:
+      - spec: openssl@1.1.1
+        prefix: /usr
+      target: []
+      providers: {}
+      compiler: []
+    libtool:
+      version: [2.4.6]
+      externals:
+      - spec: libtool@2.4.6
+        prefix: /usr
+      buildable: true
+      target: []
+      providers: {}
+      compiler: []
+    perl:
+      version: [5.30.1]
+      buildable: true
+      target: []
+      providers: {}
+      compiler: []
+    fftw:
+      variants: +openmp precision=float,double,long_double
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    icu4c:
+      buildable: true
+      version: [66.1]
+      target: []
+      providers: {}
+      compiler: []
+    strumpack:
+      variants: ~butterflypack+cuda cuda_arch=70
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    camp:
+      variants: +cuda cuda_arch=70
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    raja:
+      variants: +cuda cuda_arch=70
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    hpctoolkit:
+      variants: +cuda+mpi~papi
+    tasmanian:
+      variants: +cuda
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    superlu-dist:
+      variants: +cuda cuda_arch=70
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    sundials:
+      variants: +cuda cuda_arch=70
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    upcxx:
+      variants: +cuda
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    umpire:
+      variants: ~examples~shared+cuda cuda_arch=70
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    kokkos:
+      variants: +wrapper+cuda cuda_arch=70
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    kokkos-kernels:
+      variants: +cuda cuda_arch=70
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    hdf5:
+      variants: +hl+cxx+fortran
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    papi:
+      variants: cpu=POWER9 +cuda
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    slate:
+      variants: +cuda cuda_arch=70
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    magma:
+      variants: +cuda cuda_arch=70
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    netlib-scalapack:
+      variants: +fpic
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    netcdf-c:
+      variants: ~hdf4+mpi+parallel-netcdf+shared
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    netcdf-fortran:
+      buildable: true
+      version: [4.4.5]
+      target: []
+      compiler: []
+      providers: {}
+    parallel-netcdf:
+      variants: +cxx+fortran+fpic
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    darshan-runtime:
+      variants: +lsf+grouplogs logpath=/gpfs/alpine/darshan/summit
+      buildable: true
+      version: []
+      target: []
+      providers: {}
+      compiler: []
+    spectral:
+      variants: ~examples prologue_dir=/sw/summit/spectral/usr/local
+    all:
+      compiler: [gcc@8.3.1, gcc, clang, xl, nvhpc, pgi]
+      providers:
+        mpi: [olcf.spectrum-mpi]
+        lapack: [netlib-lapack]
+        blas: [netlib-lapack]
+        scalapack: [netlib-scalapack]
+      buildable: true
+      version: []
+      target: [ppc64le]
+  view: false
+  modules:
+    enable:
+    - lmod
+    prefix_inspections:
+      bin:
+        - PATH
+      include:
+        - CPATH
+      man:
+        - MANPATH
+      share/man:
+        - MANPATH
+      share/aclocal:
+        - ACLOCAL_PATH
+      lib64:
+        - LD_LIBRARY_PATH
+        - LIBRARY_PATH
+      lib:
+        - LD_LIBRARY_PATH
+        - LIBRARY_PATH
+      lib/pkgconfig:
+        - PKG_CONFIG_PATH
+      lib64/pkgconfig:
+        - PKG_CONFIG_PATH
+      share/pkgconfig:
+        - PKG_CONFIG_PATH
+      '':
+        - CMAKE_PREFIX_PATH
+    lmod:
+      core_compilers: [gcc@8.3.1]
+      all:
+        environment:
+          set:
+            OLCF_${PACKAGE}_ROOT: ${PREFIX}
+          unset: []
+        filter:
+          environment_blacklist: []
+        load: []
+        conflict: []
+      pgi:
+        filter:
+          environment_blacklist: [CPATH, LIBRARY_PATH]
+        load: []
+        environment:
+          unset: []
+        conflict: []
+      spectrum-mpi:
+        environment:
+          set:
+            PAMI_IBV_ENABLE_OOO_AR: '1'
+            PAMI_IBV_QP_SERVICE_LEVEL: '8'
+          unset: []
+        filter:
+          environment_blacklist: []
+        load: []
+        conflict: []
+      darshan-runtime:
+        suffixes:
+          darshan-runtime~hdf5: lite
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      gromacs:
+        suffixes:
+          gromacs ~mpi: serial
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      kokkos:
+        suffixes:
+          kokkos +openmp: omp
+          kokkos +cuda_lambda: cudalambda
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      boost:
+        suffixes:
+          boost cxxstd=14: cxx14
+          boost cxxstd=17: cxx17
+          boost visibility=global: global_symbols
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      netlib-scalapack:
+        suffixes:
+          netlib-scalapack ^openblas: openblas
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      tau:
+        suffixes:
+          tau~cuda: no_cuda
+          tau~openmp: no_omp
+          # tau+cuda: cuda
+          # tau+openmp: omp
+        filter:
+          environment_blacklist: []
+        load: []
+        environment:
+          unset: []
+        conflict: []
+      pcre:
+        suffixes:
+          pcre+jit: jit
+        filter:
+          environment_blacklist: []
+        load: []
+        environment:
+          unset: []
+        conflict: []
+      petsc:
+        suffixes:
+          petsc~cuda: no_cuda
+        filter:
+          environment_blacklist: []
+        load: []
+        environment:
+          unset: []
+        conflict: []
+      umpire:
+        suffixes:
+          umpire~openmp: no_omp
+        filter:
+          environment_blacklist: []
+        load: []
+        environment:
+          unset: []
+        conflict: []
+      hpx:
+        suffixes:
+          hpx cxxstd=14: cxx14
+          hpx cxxstd=17: cxx17
+          hpx ^boost@1.72.0: boost1.72.0
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      spectral:
+        template: olcf/modules/spectral.lua
+        filter:
+          environment_blacklist: []
+        load: []
+        environment:
+          unset: []
+        conflict: []
+      openblas:
+        suffixes:
+          openblas threads=openmp: omp
+          openblas threads=pthreads: pthreads
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      qthreads:
+        suffixes:
+          qthreads scheduler=distrib: distrib
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      adios2:
+        suffixes:
+          adios2+python: py
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      papi:
+        suffixes:
+          papi~cuda: no_gpu
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      libfabric:
+        suffixes:
+          'libfabric ^rdma-core@system': sysrdma
+        filter:
+          environment_blacklist: []
+        conflict: []
+        load: []
+        environment:
+          unset: []
+      blacklist_implicits: false
+      verbose: true
+      whitelist:
+      - mercury~mpi ^libfabric@1.12.1~kdreg  fabrics=rxm,sockets,tcp,udp,verbs
+      - libfabric fabrics=rxm,sockets,tcp,udp,verbs
+      - python@3.8.10%gcc@8.3.1 /ethjbxn
+      - python@3.7.7%gcc@8.3.1 /eltc6cg
+      - python@2.7.15%gcc@8.3.1 /6u3drkn
+      - adios2%gcc@8.3.1
+      blacklist:
+      - '%gcc@8-os'
+      - adios2@2.6.0%clang@10.0.1-0~zfp
+      - adios2@2.6.0%gcc~zfp
+      - berkeley-db
+      - binutils~nls
+      - cairo@1.16.0~X+fc+ft%gcc@8.3.1
+      - conduit+hdf5 ^hdf5~fortran
+      - cuda
+      - dyninst ^elfutils~nls
+      - elfutils~bzip2
+      - gdbm%clang
+      - gettext ^xz~pic
+      - glib
+      - glproto
+      - go-bootstrap
+      - gtkplus
+      - harfbuzz ^cairo~X
+      - hdf5@1.8.22+mpi~fortran
+      - help2man
+      - hypre+internal-superlu
+      - inputproto
+      - kbproto
+      - libassuan
+      - libdwarf
+      - libfabric fabrics=rxm,sockets,tcp # whitelist fabrics=rxm,sockets,tcp,udp,verbs
+      - libfontenc
+      - libgcrypt
+      - libgd
+      - libgpg-error
+      - libiconv
+      - libidn2
+      - libksba
+      - libmonitor~dlopen
+      - libpciaccess
+      - libpthread-stubs
+      - libsigsegv
+      - libsodium
+      - libtool@2.4.2
+      - libunistring
+      - libunwind~pic~xz
+      - libuuid
+      - libx11
+      - libxau
+      - libxcb
+      - libxdmcp
+      - libxext
+      - libxfont
+      - libxml2 ^xz~pic
+      - libxpm
+      - libxslt
+      - lua
+      - m4
+      - mercury~mpi ^libfabric@1.12.1~kdreg fabrics=rxm,sockets,tcp
+      - meson
+      - mkfontdir
+      - mkfontscale
+      - mpfr
+      - mpich
+      - msgpack-c
+      - nasm
+      - ncurses
+      - netlib-scalapack@2.1.0%gcc@10.2.0 ^openblas patches=865703b4f405543bbd583413fdeff2226dfda908be33639276c06e5aa7ae2cae
+      - npth
+      - numactl
+      - openssh
+      - openssl
+      - pango ^cairo~pdf
+      - papi@6.0.0.1%gcc@8.3.1 ^cuda@11.1.1 # FIXME: find spec triggering this build, possibly HPX?
+      - pinentry
+      - pkgconf
+      - popt
+      - py-
+      - py-certifi
+      - py-docutils
+      - py-mako
+      - py-markupsafe
+      - py-msgpack
+      - py-pip
+      - py-pygments
+      - py-pyyaml
+      - py-setuptools
+      - py-virtualenv
+      - py-wheel
+      - python
+      - readline
+      - rdma-core@system
+      - slurm
+      - sqlite%clang
+      - tcl
+      - tcsh
+      - util-linux-uuid
+      - util-macros
+      - xcb-proto
+      - xextproto
+      - xtrans
+      - xz~pic
+      - zsh
+      hash_length: 0
+      hierarchy: []
+      projections: {}
+      core_specs:
+      - adios2%gcc@8.3.1
+      - adios@1.13.1%gcc@8.3.1
+      - magma@2.5.3%gcc@8.3.1 ^cuda@11.0.3
+      - gromacs%gcc@8.3.1+mpi
+      - gromacs%gcc@8.3.1~mpi
+      - amgx%gcc@8.3.1 ^cuda@10.2.89
+      - scorep@7.0%gcc@8.3.1+mpi+papi~pdt~shmem~unwind
+      - darshan-runtime@3.2.1%gcc@8.3.1+hdf5
+      - darshan-runtime@3.2.1%gcc@8.3.1~hdf5
+      - darshan-runtime@3.3.0%gcc@8.3.1+hdf5
+      - darshan-runtime@3.3.0%gcc@8.3.1~hdf5
+  config:
+    install_tree:
+      root: ${FACSPACK_ENV}/opt
+      projections:
+        all: ${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}
+    module_roots:
+      tcl: ${FACSPACK_ENV_MODULEROOT}/flat
+      lmod: ${FACSPACK_ENV_MODULEROOT}/spack
+    template_dirs:
+    - ${FACSPACK_CONF_HOST}/templates
+    - ${FACSPACK_CONF_COMMON}/spack/templates
+    - $spack/share/spack/templates
+    build_stage:
+    - $tempdir/$user/spack-stage
+    - $spack/var/spack/stage
+    source_cache: ${FACSPACK_CONF_COMMON}/mirrors/sources
+    extensions:
+    - /sw/sources/facspack/share/spack/extensions/spack-olcf
+    misc_cache: ${FACSPACK_ENV}/.mcache
+    verify_ssl: true
+    install_missing_compilers: false
+    checksum: true
+    dirty: false
+    build_language: C
+    build_jobs: 6
+    ccache: false
+    db_lock_timeout: 120
+    package_lock_timeout: null
+    shared_linking: rpath
+    allow_sgid: true
+    concretizer: original
+    locks: true
+    suppress_gpg_warnings: false
+    connect_timeout: 10
+    test_stage: ~/.spack/test
+  concretization: separately
+  compilers:
+  - compiler:
+      spec: gcc@8.3.1
+      operating_system: rhel8
+      modules: []
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      extra_rpaths: []
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+      flags: {}
+  - compiler:
+      spec: gcc@8-os
+      operating_system: rhel8
+      modules: []
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      extra_rpaths: []
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+      flags: {}
+  - compiler:
+      spec: gcc@7.5.0
+      operating_system: rhel8
+      modules: [gcc/7.5.0]
+      paths:
+        cc: gcc
+        cxx: g++
+        f77: gfortran
+        fc: gfortran
+      extra_rpaths: []
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+      flags: {}
+  - compiler:
+      spec: gcc@9.1.0
+      operating_system: rhel8
+      modules: [gcc/9.1.0]
+      paths:
+        cc: gcc
+        cxx: g++
+        f77: gfortran
+        fc: gfortran
+      extra_rpaths: []
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+      flags: {}
+  - compiler:
+      spec: gcc@9.3.0
+      operating_system: rhel8
+      modules: [gcc/9.3.0]
+      paths:
+        cc: gcc
+        cxx: g++
+        f77: gfortran
+        fc: gfortran
+      extra_rpaths: []
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+      flags: {}
+  - compiler:
+      spec: gcc@10.2.0
+      operating_system: rhel8
+      modules: [gcc/10.2.0]
+      paths:
+        cc: gcc
+        cxx: g++
+        f77: gfortran
+        fc: gfortran
+      extra_rpaths: []
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+      flags: {}
+  - compiler:
+      spec: gcc@11.1.0
+      operating_system: rhel8
+      modules: [gcc/11.1.0]
+      paths:
+        cc: gcc
+        cxx: g++
+        f77: gfortran
+        fc: gfortran
+      extra_rpaths: []
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+      flags: {}
+  - compiler:
+      # siterc must ignore certain GNU arguments, eg
+      # `switch -Wno-implicit-function-declaration is hide;`
+      spec: pgi@20.1
+      operating_system: rhel8
+      modules: [pgi/20.1]
+      paths:
+        cc: pgcc
+        cxx: pgc++
+        f77: pgfortran
+        fc: pgfortran
+      extra_rpaths: []
+      environment: {}
+      flags: {}
+  - compiler:
+      # siterc must ignore certain GNU arguments, eg
+      # `switch -Wno-implicit-function-declaration is hide;`
+      spec: pgi@20.4
+      operating_system: rhel8
+      modules: [pgi/20.4]
+      paths:
+        cc: pgcc
+        cxx: pgc++
+        f77: pgfortran
+        fc: pgfortran
+      extra_rpaths: []
+      environment: {}
+      flags: {}
+  - compiler:
+      spec: nvhpc@20.9
+      operating_system: rhel8
+      modules: [nvhpc/20.9]
+      paths:
+        cc: nvc
+        cxx: nvc++
+        f77: nvfortran
+        fc: nvfortran
+      extra_rpaths: []
+      environment: {}
+      flags: {}
+  - compiler:
+      spec: nvhpc@21.2
+      operating_system: rhel8
+      modules: [nvhpc/21.2]
+      paths:
+        cc: nvc
+        cxx: nvc++
+        f77: nvfortran
+        fc: nvfortran
+      extra_rpaths: []
+      environment: {}
+      flags: {}
+  - compiler:
+      spec: nvhpc@21.3
+      operating_system: rhel8
+      modules: [nvhpc/21.3]
+      paths:
+        cc: nvc
+        cxx: nvc++
+        f77: nvfortran
+        fc: nvfortran
+      extra_rpaths: []
+      environment: {}
+      flags: {}
+  - compiler:
+      spec: nvhpc@21.5
+      operating_system: rhel8
+      modules: [nvhpc/21.5]
+      paths:
+        cc: nvc
+        cxx: nvc++
+        f77: nvfortran
+        fc: nvfortran
+      extra_rpaths: []
+      environment: {}
+      flags: {}
+  - compiler:
+      spec: nvhpc@21.7
+      operating_system: rhel8
+      modules: [nvhpc/21.7]
+      paths:
+        cc: nvc
+        cxx: nvc++
+        f77: nvfortran
+        fc: nvfortran
+      extra_rpaths: []
+      environment: {}
+      flags: {}
+  - compiler:
+      spec: clang@10.0.1-0
+      operating_system: rhel8
+      modules: [llvm/10.0.1]
+      paths:
+        cc: /sw/summit/llvm/10.0.1/10.0.1-0/bin/clang
+        cxx: /sw/summit/llvm/10.0.1/10.0.1-0/bin/clang++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      extra_rpaths: []
+      environment: {}
+      flags: {}
+  - compiler:
+      spec: clang@12.0.0-0
+      operating_system: rhel8
+      modules: [llvm/12.0.0]
+      paths:
+        cc: /sw/summit/llvm/12.0.0/12.0.0-0/bin/clang
+        cxx: /sw/summit/llvm/12.0.0/12.0.0-0/bin/clang++
+        f77: /sw/summit/llvm/12.0.0/12.0.0-0/bin/flang
+        fc: /sw/summit/llvm/12.0.0/12.0.0-0/bin/flang
+      extra_rpaths: []
+      environment: {}
+      flags: {}
+  - compiler:
+      spec: xl@16.1.1-8
+      operating_system: rhel8
+      modules: [xl/16.1.1-8]
+      paths:
+        cc: /sw/summit/xl/16.1.1-8-1/xlC/16.1.1/bin/xlc_r
+        cxx: /sw/summit/xl/16.1.1-8-1/xlC/16.1.1/bin/xlc++_r
+        f77: /sw/summit/xl/16.1.1-8-1/xlf/16.1.1/bin/xlf_r
+        fc: /sw/summit/xl/16.1.1-8-1/xlf/16.1.1/bin/xlf2008_r
+      extra_rpaths:
+      - /sw/summit/xl/16.1.1-8-1/lib
+      - /sw/summit/xl/16.1.1-8-1/xlf/16.1.1/lib
+      - /sw/summit/xl/16.1.1-8-1/xlC/16.1.1/lib
+      environment: {}
+      flags: {}
+  - compiler:
+      spec: xl@16.1.1-10
+      operating_system: rhel8
+      modules: [xl/16.1.1-10]
+      paths:
+        cc: /sw/summit/xl/16.1.1-10/xlC/16.1.1/bin/xlc_r
+        cxx: /sw/summit/xl/16.1.1-10/xlC/16.1.1/bin/xlc++_r
+        f77: /sw/summit/xl/16.1.1-10/xlf/16.1.1/bin/xlf_r
+        fc: /sw/summit/xl/16.1.1-10/xlf/16.1.1/bin/xlf2008_r
+      extra_rpaths:
+      - /sw/summit/xl/16.1.1-10/lib
+      - /sw/summit/xl/16.1.1-10/xlf/16.1.1/lib
+      - /sw/summit/xl/16.1.1-10/xlC/16.1.1/lib
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+      flags: {}
+  - compiler:
+      spec: xl@16.1.1-beta103
+      operating_system: rhel8
+      modules: [xl/16.1.1-beta103]
+      paths:
+        cc: /sw/summit/xl/16.1.1-beta103/xlC/16.1.1/bin/xlc_r
+        cxx: /sw/summit/xl/16.1.1-beta103/xlC/16.1.1/bin/xlc++_r
+        f77: /sw/summit/xl/16.1.1-beta103/xlf/16.1.1/bin/xlf_r
+        fc: /sw/summit/xl/16.1.1-beta103/xlf/16.1.1/bin/xlf2008_r
+      extra_rpaths:
+      - /sw/summit/xl/16.1.1-beta103/lib
+      - /sw/summit/xl/16.1.1-beta103/xlf/16.1.1/lib
+      - /sw/summit/xl/16.1.1-beta103/xlC/16.1.1/lib
+      environment:
+        append_path:
+          PKG_CONFIG_PATH: /usr/lib64/pkgconfig
+      flags: {}


### PR DESCRIPTION
Added current spack.yaml files for OLCF's Summit and Spock systems.
Added e4s "spack find" output for Summit and Spock for E4S 21.05 releases.