### PR TITLE
remove module hash, provide default user install location

### DIFF
--- a/ANL/JLSE/Arcticus/E4S-21.08/README.md
+++ b/ANL/JLSE/Arcticus/E4S-21.08/README.md
@@ -6,7 +6,7 @@ Note that this repo is set up to be CI-ready, just by copying the .gitlab-ci.yml
 
 - [${WORKING_DIR}/spack.yaml](https://github.com/spack/spack-configs/blob/main/ANL/JLSE/Arcticus/E4S-21.08/spack.yaml): The spack.yaml in WORKING_DIR is used for building E4S to populate the buildcache in the named mirror.
 - [${WORKING_DIR}/prod/spack.yaml](https://github.com/spack/spack-configs/blob/main/ANL/JLSE/Arcticus/E4S-21.08/prod/spack.yaml): This is the spack.yaml used for deployment of E4S from the generated buildcache to the desired location.
-- [${WORKING_DIR}/.gitlab-ci.yml](https://github.com/spack/spack-configs/blob/main/ANL/JLSE/Arcticus/E4S-21.08/.gitlab-ci.yaml): Gitlab CI file to automate deployment using Gitlab. (Copy it to base directory to enable CI)
+- [${WORKING_DIR}/.gitlab-ci.yml](https://github.com/spack/spack-configs/blob/main/ANL/JLSE/Arcticus/E4S-21.08/.gitlab-ci.yml): Gitlab CI file to automate deployment using Gitlab. (Copy it to base directory to enable CI)
 - [site_config](https://github.com/spack/spack-configs/blob/main/ANL/JLSE/Arcticus/E4S-21.08/site_config): spack configuration at *site* scope that overrides default. This helps ensure user can get necessary defaults when they use this spack instance. These yaml files are copied to the spack installation during the build and deploy stages. 
 
 ## Project Variables

--- a/ANL/JLSE/Arcticus/E4S-21.08/README.md
+++ b/ANL/JLSE/Arcticus/E4S-21.08/README.md
@@ -4,10 +4,10 @@ The e4s 21.08 stack is based on [E4S-Project/e4s](https://github.com/E4S-Project
 
 Note that this repo is set up to be CI-ready, just by copying the .gitlab-ci.yml from this directory to the base directory of the repository. The environment variable WORKING_DIR maps back to this directory.
 
-- [${WORKING_DIR}/spack.yaml]: The spack.yaml in WORKING_DIR is used for building E4S to populate the buildcache in the named mirror.
-- [${WORKING_DIR}/prod/spack.yaml]: This is the spack.yaml used for deployment of E4S from the generated buildcache to the desired location.
-- [${WORKING_DIR}/.gitlab-ci.yml]: Gitlab CI file to automate deployment using Gitlab. (Copy it to base directory to enable CI)
-- [site_config]: spack configuration at *site* scope that overrides default. This helps ensure user can get necessary defaults when they use this spack instance. These yaml files are copied to the spack installation during the build and deploy stages. 
+- [${WORKING_DIR}/spack.yaml](https://github.com/spack/spack-configs/blob/main/ANL/JLSE/Arcticus/E4S-21.08/spack.yaml): The spack.yaml in WORKING_DIR is used for building E4S to populate the buildcache in the named mirror.
+- [${WORKING_DIR}/prod/spack.yaml](https://github.com/spack/spack-configs/blob/main/ANL/JLSE/Arcticus/E4S-21.08/prod/spack.yaml): This is the spack.yaml used for deployment of E4S from the generated buildcache to the desired location.
+- [${WORKING_DIR}/.gitlab-ci.yml](https://github.com/spack/spack-configs/blob/main/ANL/JLSE/Arcticus/E4S-21.08/.gitlab-ci.yaml): Gitlab CI file to automate deployment using Gitlab. (Copy it to base directory to enable CI)
+- [site_config](https://github.com/spack/spack-configs/blob/main/ANL/JLSE/Arcticus/E4S-21.08/site_config): spack configuration at *site* scope that overrides default. This helps ensure user can get necessary defaults when they use this spack instance. These yaml files are copied to the spack installation during the build and deploy stages. 
 
 ## Project Variables
 

--- a/ANL/JLSE/Arcticus/E4S-21.08/prod/spack.yaml
+++ b/ANL/JLSE/Arcticus/E4S-21.08/prod/spack.yaml
@@ -313,8 +313,9 @@ spack:
     - tcl
     tcl:
       blacklist_implicits: true
-#      hash_length: 0
-      hash_length: 4
+      hash_length: 0
+      blacklist:
+      - py-warpx
       naming_scheme: '{name}/{version}-{compiler.name}-{compiler.version}'
       all:
         conflict:

--- a/ANL/JLSE/Arcticus/E4S-21.08/site_config/config.yaml
+++ b/ANL/JLSE/Arcticus/E4S-21.08/site_config/config.yaml
@@ -5,4 +5,11 @@ config:
 #   - ~/.spack/stage
   db_lock_timeout: 60
 
+  install_tree:
+    padded_length: 127
+    root: $HOME/spack-workspace/software
+  source_cache: $HOME/.spack/cache
+  module_roots:
+    tcl: $HOME/spack-workspace/modules
+    lmod: $HOME/spack-workspace/modules
 


### PR DESCRIPTION
This covers the requested revisions. 

Since py-warpx generates three identical specs, it was blacklisted. There were no other name conflicts. 