### PR TITLE
Add configuration for AWS ParallelCluster

### DIFF
--- a/AWS/parallelcluster/config.yaml
+++ b/AWS/parallelcluster/config.yaml
@@ -1,0 +1,2 @@
+config:
+  install_hash_length: 8

--- a/AWS/parallelcluster/mirrors.yaml
+++ b/AWS/parallelcluster/mirrors.yaml
@@ -1,0 +1,2 @@
+mirrors:
+  binary_mirror: https://binaries.spack.io/develop

--- a/AWS/parallelcluster/modules.yaml
+++ b/AWS/parallelcluster/modules.yaml
@@ -1,0 +1,15 @@
+modules:
+  default:
+    enable:
+      - tcl
+    tcl:
+      projections:
+        all: '{name}/{version}-{compiler.name}-{compiler.version}'
+      all:
+        conflict:
+          - '{name}'
+        environment:
+          set:
+            '{name}_ROOT': '{prefix}'
+        # Automatically load dependencies
+        autoload: all

--- a/AWS/parallelcluster/packages-graviton2.yaml
+++ b/AWS/parallelcluster/packages-graviton2.yaml
@@ -1,0 +1,38 @@
+
+packages:
+  libfabric:
+    externals:
+    - spec: libfabric@${LIBFABRIC_VERSION} fabrics=efa
+      modules:
+      - ${LIBFABRIC_MODULE}
+    buildable: False
+  slurm:
+    externals:
+    - spec: slurm@${SLURM_VERSION} +pmix
+      prefix: /opt/slurm/
+    buildable: False
+  gcc:
+     target: [aarch64]
+     compiler: [gcc]
+  arm:
+    target: [aarch64]
+    compiler: [gcc]
+  nvhpc:
+    target: [aarch64]
+    compiler: [gcc]
+  llvm:
+    variants: ~lldb
+  gromacs:
+    require:
+    - one_of: ["gromacs@2021.3 %gcc ^fftw^openmpi"]
+  all:
+    compiler: [nvhpc, gcc, clang]
+    providers:
+      blas: [armpl-gcc, openblas]
+      fftw-api: [armpl-gcc, fftw]
+      lapack: [armpl-gcc, openblas]
+      mpi: [openmpi]
+      scalapack: [netlib-scalapack]
+    permissions:
+      read: world
+      write: user

--- a/AWS/parallelcluster/packages-icelake.yaml
+++ b/AWS/parallelcluster/packages-icelake.yaml
@@ -1,0 +1,65 @@
+packages:
+  intel-oneapi-mpi:
+    variants: +external-libfabric generic-names=True
+  intel-mpi:
+    variants: +external-libfabric
+  gcc:
+    target: [x86_64]
+    compiler: [gcc]
+    require:
+    - one_of: ["+binutils ^binutils+gas+ld"]
+  intel-oneapi-compilers:
+     target: [x86_64]
+     compiler: [intel]
+  intel-parallel-studio:
+     target: [x86_64]
+     compiler: [intel]
+  openmpi:
+    variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
+  libfabric:
+    externals:
+    - spec: libfabric@${LIBFABRIC_VERSION} fabrics=efa
+      modules:
+      - ${LIBFABRIC_MODULE}
+    buildable: False
+  slurm:
+    externals:
+    - spec: slurm@${SLURM_VERSION} +pmix
+      prefix: /opt/slurm/
+    buildable: False
+  gromacs:
+    require:
+    - one_of: ["gromacs@2020.1 +lapack+blas %intel ^intel-mpi ^intel-oneapi-mkl"]
+  quantum-espresso:
+    require:
+    - one_of: ["quantum-espresso@6.6 %intel ^intel-mkl ^intel-oneapi-mpi"]
+  openfoam:
+    require:
+    - one_of: ["openfoam@2006_220610 cxxflags='-march=sandybridge' %intel ^scotch@6.0.9 ^intel-mpi"]
+  wrf:
+    require:
+    - one_of: ["wrf@4 build_type=dm+sm %intel ^intel-oneapi-mpi"]
+  lammps:
+    require:
+    - one_of: ["lammps@develop lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package +intel %intel ^intel-oneapi-mpi ^intel-oneapi-mkl"]
+  mpas-model:
+    require:
+    - one_of: ["precision=single %intel ^parallelio+pnetcdf ^intel-oneapi-mpi"]
+  py-devito:
+    require:
+    - one_of: ["+mpi %intel ^intel-oneapi-mpi ^py-scipy%gcc"]
+  all:
+    compiler: [intel, gcc, clang]
+    providers:
+      blas: [intel-oneapi-mkl, intel-mkl]
+      daal: [intel-oneapi-dal, intel-daal]
+      fftw-api: [intel-oneapi-mkl, intel-mkl]
+      ipp: [intel-oneapi-ipp, intel-ipp]
+      lapack: [intel-oneapi-mkl, intel-mkl]
+      mkl: [intel-oneapi-mkl, intel-mkl]
+      mpi: [intel-mpi, intel-oneapi-mpi, openmpi]
+      tbb: [intel-oneapi-tbb, intel-tbb]
+      scalapack: [intel-oneapi-mkl, intel-mkl]
+    permissions:
+      read: world
+      write: user

--- a/AWS/parallelcluster/packages-skylake_avx512.yaml
+++ b/AWS/parallelcluster/packages-skylake_avx512.yaml
@@ -1,0 +1,60 @@
+packages:
+  intel-oneapi-mpi:
+    variants: +external-libfabric generic-names=True
+  intel-mpi:
+    variants: +external-libfabric
+  gcc:
+     target: [x86_64]
+     compiler: [gcc]
+  intel-oneapi-compilers:
+     target: [x86_64]
+     compiler: [intel]
+  intel-parallel-studio:
+     target: [x86_64]
+     compiler: [intel]
+  openmpi:
+    variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
+  libfabric:
+    externals:
+    - spec: libfabric@${LIBFABRIC_VERSION} fabrics=efa
+      modules:
+      - ${LIBFABRIC_MODULE}
+    buildable: False
+  slurm:
+    externals:
+    - spec: slurm@${SLURM_VERSION} +pmix
+      prefix: /opt/slurm/
+    buildable: False
+  gromacs:
+   require:
+   - one_of: ["+lapack+blas%intel ^intel-mpi ^intel-oneapi-mkl"]
+  quantum-espresso:
+    require:
+    - one_of: ["quantum-espresso@6.6 %intel ^intel-mkl ^intel-oneapi-mpi"]
+  openfoam:
+    require:
+    - one_of: ["openfoam@2112_220610 %intel ^scotch@6.0.9 ^intel-oneapi-mpi"]
+  wrf:
+    require:
+    - one_of: ["wrf@4 build_type=dm+sm  %intel ^intel-oneapi-mpi"]
+  lammps:
+    require:
+    - one_of: ["lammps@develop lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package +intel %intel ^intel-oneapi-mkl ^intel-oneapi-mpi"]
+  mpas-model:
+    require:
+    - one_of: ["mpas-model %intel precision=single ^parallelio+pnetcdf ^intel-oneapi-mpi"]
+  all:
+    compiler: [intel, gcc, clang]
+    providers:
+      blas: [intel-oneapi-mkl, intel-mkl]
+      daal: [intel-oneapi-dal, intel-daal]
+      fftw-api: [intel-oneapi-mkl, intel-mkl]
+      ipp: [intel-oneapi-ipp, intel-ipp]
+      lapack: [intel-oneapi-mkl, intel-mkl]
+      mkl: [intel-oneapi-mkl, intel-mkl]
+      mpi: [intel-mpi, intel-oneapi-mpi, openmpi]
+      tbb: [intel-oneapi-tbb, intel-tbb]
+      scalapack: [intel-oneapi-mkl, intel-mkl]
+    permissions:
+      read: world
+      write: user

--- a/AWS/parallelcluster/packages-zen2.yaml
+++ b/AWS/parallelcluster/packages-zen2.yaml
@@ -1,0 +1,60 @@
+packages:
+  intel-oneapi-mpi:
+    variants: +external-libfabric generic-names=True
+  intel-mpi:
+    variants: +external-libfabric
+  gcc:
+     target: [x86_64]
+     compiler: [gcc]
+  intel-oneapi-compilers:
+     target: [x86_64]
+     compiler: [intel]
+  intel-parallel-studio:
+     target: [x86_64]
+     compiler: [intel]
+  openmpi:
+    variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
+  libfabric:
+    externals:
+    - spec: libfabric@${LIBFABRIC_VERSION} fabrics=efa
+      modules:
+      - ${LIBFABRIC_MODULE}
+    buildable: False
+  slurm:
+    externals:
+    - spec: slurm@${SLURM_VERSION} +pmix
+      prefix: /opt/slurm/
+    buildable: False
+  gromacs:
+   require:
+   - one_of: ["+lapack+blas %intel ^intel-mpi ^intel-oneapi-mkl"]
+  quantum-espresso:
+    require:
+    - one_of: ["quantum-espresso@6.6 %intel ^intel-mkl ^intel-oneapi-mpi"]
+  openfoam:
+    require:
+    - one_of: ["openfoam@2112_220610 %intel ^scotch@6.0.9 ^intel-oneapi-mpi"]
+  wrf:
+    require:
+    - one_of: ["wrf@4 build_type=dm+sm %intel ^intel-oneapi-mpi"]
+  lammps:
+    require:
+    - one_of: ["lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package %intel ^intel-oneapi-mpi ^intel-oneapi-mkl"]
+  mpas-model:
+    require:
+    - one_of: ["precision=single %intel ^parallelio+pnetcdf ^intel-oneapi-mpi"]
+  all:
+    compiler: [intel, gcc, clang]
+    providers:
+      blas: [intel-oneapi-mkl, intel-mkl]
+      daal: [intel-oneapi-dal, intel-daal]
+      fftw-api: [intel-oneapi-mkl, intel-mkl]
+      ipp: [intel-oneapi-ipp, intel-ipp]
+      lapack: [intel-oneapi-mkl, intel-mkl]
+      mkl: [intel-oneapi-mkl, intel-mkl]
+      mpi: [intel-mpi, intel-oneapi-mpi, openmpi]
+      tbb: [intel-oneapi-tbb, intel-tbb]
+      scalapack: [intel-oneapi-mkl, intel-mkl]
+    permissions:
+      read: world
+      write: user

--- a/AWS/parallelcluster/postinstall.sh
+++ b/AWS/parallelcluster/postinstall.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -e
+
+##############################################################################################
+# # This script will setup Spack and best practices for a few applications.                  #
+# # Use as postinstall in AWS ParallelCluster (https://docs.aws.amazon.com/parallelcluster/) #
+##############################################################################################
+
+# Install onto first shared storage device
+. /etc/parallelcluster/cfnconfig || {
+    echo "Cannot find ParallelCluster configs"
+    echo "Installing Spack into /shared/spack for ec2-user."
+    cfn_ebs_shared_dirs="/shared"
+    cfn_cluster_user="ec2-user"
+}
+
+install_path=${SPACK_ROOT:-"${cfn_ebs_shared_dirs}/spack"}
+spack_branch="develop"
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+major_version() {
+    pcluster_version=$(grep -oE '[0-9]*\.[0-9]*\.[0-9]*' /opt/parallelcluster/.bootstrapped)
+    echo "${pcluster_version/\.*}"
+}
+
+# Make first user owner of Spack installation when script exits.
+fix_owner() {
+    rc=$?
+    if [ -z "${SPACK_ROOT}" ]
+    then
+        chown -R ${cfn_cluster_user}:${cfn_cluster_user} "${install_path}"
+    fi
+    exit $rc
+}
+trap "fix_owner" SIGINT EXIT
+
+download_spack() {
+    if [ -z "${SPACK_ROOT}" ]
+    then
+        [ -d ${install_path} ] || \
+            git clone https://github.com/spack/spack -b ${spack_branch} ${install_path}
+    fi
+}
+
+architecture() {
+    lscpu  | grep "Architecture:" | awk '{print $2}'
+}
+
+# zen3 EC2 instances (e.g. hpc6a) is misidentified as zen2 so zen3 packages are found under packages-zen2.yaml.
+target() {
+    (
+        . ${install_path}/share/spack/setup-env.sh
+        spack arch -t
+    )
+}
+
+set_pcluster_defaults() {
+    # Set versions of pre-installed software in packages.yaml
+    SLURM_VERSION=$(. /etc/profile && sinfo --version | cut -d' ' -f 2 | sed -e 's?\.?-?g')
+    LIBFABRIC_MODULE=$(. /etc/profile && module avail libfabric 2>&1 | grep libfabric | head -n 1 | sed -e 's?~??g' | xargs )
+    LIBFABRIC_MODULE_VERSION=$(. /etc/profile && module avail libfabric 2>&1 | grep libfabric | head -n 1 |  cut -d / -f 2 | sed -e 's?~??g' | xargs )
+    LIBFABRIC_VERSION=${LIBFABRIC_MODULE_VERSION//amzn*}
+    GCC_VERSION=$(gcc -v 2>&1 |tail -n 1| awk '{print $3}' )
+
+    # Write the above as actual yaml file and only parse the \$.
+    mkdir -p ${install_path}/etc/spack
+        curl -Ls https://raw.githubusercontent.com/spack/spack-configs/main/AWS/parallelcluster/packages-"$(target)".yaml -o ${scriptdir}/packages.yaml
+    eval "echo \"$(cat ${scriptdir}/packages.yaml)\"" > ${install_path}/etc/spack/packages.yaml
+
+    for f in mirrors modules config; do
+        aws s3 cp s3://spack-configs/AWS/parallelcluster/${f}.yaml  ${install_path}/etc/spack/${f}.yaml
+    done
+
+}
+
+setup_spack() {
+    cd "${install_path}"
+
+    # Load spack at login
+    if [ -z "${SPACK_ROOT}" ]
+    then
+        echo ". ${install_path}/share/spack/setup-env.sh" > /etc/profile.d/spack.sh
+        echo ". ${install_path}/share/spack/setup-env.csh" > /etc/profile.d/spack.csh
+    fi
+
+    . "${install_path}/share/spack/setup-env.sh"
+    spack compiler add --scope site
+    spack external find --scope site
+
+    # Remove all autotools/buildtools packages. These versions need to be managed by spack or it will
+    # eventually end up in a version mismatch (e.g. when compiling gmp).
+    spack tags build-tools | xargs -I {} spack config --scope site rm packages:{}
+    spack buildcache keys --install --trust
+}
+
+install_packages() {
+    . /etc/profile.d/spack.sh
+
+    # Compiler needed for all kinds of codes. It makes no sense not to install it.
+    if [ "x86_64" == "$(architecture)" ]
+    then
+        packages_yaml="$(spack config --scope site edit compilers --print-file)"
+        SPACK_OS=$(spack arch -o)
+        # Add oneapi@latest & intel@latest
+        STUB_ONEAPI_COMPILER=$(spack list --format version_json intel-oneapi-compilers-classic | jq -rc .[0].versions[] | sort | tail -n1 | awk '{print "intel@"$1}')
+        echo -e "- compiler:\n    target:     x86_64\n    operating_system:   ${SPACK_OS}\n    modules:    []\n    spec:       ${STUB_ONEAPI_COMPILER}\n    paths:\n      cc:       /usr/bin/true\n      cxx:      /usr/bin/true\n      f77:      /usr/bin/true\n      fc:       /usr/bin/true" \
+             >> "${packages_yaml}"
+        spack install intel-oneapi-compilers-classic %${STUB_ONEAPI_COMPILER} ^patchelf%gcc
+        # Remove stubs
+        head -n -10 "${packages_yaml}" > $$.tmp && mv $$.tmp "${packages_yaml}"
+        (
+            . "$(spack location -i intel-oneapi-compilers)/setvars.sh"
+            spack compiler add --scope site
+        )
+    fi
+
+    # Install any specs provided to the script.
+    for spec in "$@"
+    do
+        spack install "${spec}"
+    done
+}
+
+if [ "3" != "$(major_version)" ]; then
+    echo "ParallelCluster version $(major_version) not supported."
+    exit 1
+fi
+
+download_spack |& tee -a /var/log/spack-postinstall.log
+set_pcluster_defaults |& tee -a /var/log/spack-postinstall.log
+setup_spack |& tee -a /var/log/spack-postinstall.log
+install_packages "$@" |& tee -a /var/log/spack-postinstall.log


### PR DESCRIPTION
- This includes setup for skylake, icelake, zen3, and grv2 based clusters.
- Includes pre-defined recipes for gromacs, quantum-espresso, openfoam, wrf,
- lammps, mpas-model, and py-devito.
- Use `postinstall.sh` in ParallelCluster cluster creation or
- Run `curl -L https://raw.githubusercontent.com/spack/spack-configs/AWS/parallelcluster/postinstall.sh | sudo bash`
- zen3 is recognized as zen2 by archspec, so using zen2 only.