### PR TITLE
Update AWS packages.yaml files

### DIFF
--- a/AWS/parallelcluster/packages-aarch64.yaml
+++ b/AWS/parallelcluster/packages-aarch64.yaml
@@ -1,7 +1,6 @@
 ---  # aarch64 packages (Basically only compiler)
 packages:
   gcc:
-    compiler: [gcc]
     require:
       - one_of: ["gcc@12 +binutils ^binutils@2.37 target=aarch64"]
   all:

--- a/AWS/parallelcluster/packages-icelake.yaml
+++ b/AWS/parallelcluster/packages-icelake.yaml
@@ -25,8 +25,7 @@ packages:
   libfabric:
     buildable: false
     externals:
-      - modules:
-          - ${LIBFABRIC_MODULE}
+      - prefix: /opt/amazon/efa/
         spec: libfabric@${LIBFABRIC_VERSION} fabrics=efa
   libunistring:
     require:

--- a/AWS/parallelcluster/packages-neoverse_n1.yaml
+++ b/AWS/parallelcluster/packages-neoverse_n1.yaml
@@ -13,8 +13,7 @@ packages:
   libfabric:
     buildable: false
     externals:
-      - modules:
-          - ${LIBFABRIC_MODULE}
+      - prefix: /opt/amazon/efa/
         spec: libfabric@${LIBFABRIC_VERSION} fabrics=efa
   llvm:
     variants: ~lldb

--- a/AWS/parallelcluster/packages-neoverse_n1.yaml
+++ b/AWS/parallelcluster/packages-neoverse_n1.yaml
@@ -1,10 +1,6 @@
 ---  # Neoverse N1 packages
 packages:
-  acfl:
-    target: [aarch64]
-    compiler: [gcc]
   gcc:
-    compiler: [gcc]
     require:
       - one_of: ["gcc@12 +binutils ^binutils@2.37 target=aarch64"]
   gromacs:
@@ -17,9 +13,6 @@ packages:
         spec: libfabric@${LIBFABRIC_VERSION} fabrics=efa
   llvm:
     variants: ~lldb
-  nvhpc:
-    compiler: [gcc]
-    target: [aarch64]
   mpich:
     require:
       - one_of: ["mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"]

--- a/AWS/parallelcluster/packages-neoverse_v1.yaml
+++ b/AWS/parallelcluster/packages-neoverse_v1.yaml
@@ -13,8 +13,7 @@ packages:
   libfabric:
     buildable: false
     externals:
-      - modules:
-          - ${LIBFABRIC_MODULE}
+      - prefix: /opt/amazon/efa/
         spec: libfabric@${LIBFABRIC_VERSION} fabrics=efa
   mpas-model:
     require: "precision=single make_target=llvm %arm ^parallelio+pnetcdf"

--- a/AWS/parallelcluster/packages-neoverse_v1.yaml
+++ b/AWS/parallelcluster/packages-neoverse_v1.yaml
@@ -1,10 +1,6 @@
 ---  # Neoverse V1 packages
 packages:
-  acfl:
-    target: [aarch64]
-    compiler: [gcc]
   gcc:
-    compiler: [gcc]
     require:
       - one_of: ["gcc@12 +binutils ^binutils@2.37 target=aarch64"]
   gromacs:

--- a/AWS/parallelcluster/packages-skylake_avx512.yaml
+++ b/AWS/parallelcluster/packages-skylake_avx512.yaml
@@ -25,8 +25,7 @@ packages:
   libfabric:
     buildable: false
     externals:
-      - modules:
-          - ${LIBFABRIC_MODULE}
+      - prefix: /opt/amazon/efa/
         spec: libfabric@${LIBFABRIC_VERSION} fabrics=efa
   libunistring:
     require:

--- a/AWS/parallelcluster/packages-zen2.yaml
+++ b/AWS/parallelcluster/packages-zen2.yaml
@@ -31,8 +31,7 @@ packages:
   libfabric:
     buildable: false
     externals:
-      - modules:
-          - ${LIBFABRIC_MODULE}
+      - prefix: /opt/amazon/efa/
         spec: libfabric@${LIBFABRIC_VERSION} fabrics=efa
   libunistring:
     require:


### PR DESCRIPTION
Switch from "module" based external libfabric package to "prefix" based package.  The modules were causing problems in a headless build of openmpi.

Also remove "target" and "compiler" lines from package-specific sections, in order to be compatible with v0.22.