### PR TITLE
[AWS] Add option to use x86_64_v4/neoverse_v1 buildcache

### DIFF
--- a/AWS/parallelcluster/postinstall.sh
+++ b/AWS/parallelcluster/postinstall.sh
@@ -236,14 +236,6 @@ generic_target() {
     )
 }
 
-cp_packages_yaml() {
-    (
-        . "${install_path}/share/spack/setup-env.sh"
-        packages_yaml="${SPACK_ROOT}/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-$(generic_target)/packages.yaml"
-        [ -f "${packages_yaml}" ] && cp "${packages_yaml}" /tmp/packages.yaml || echo "404: Not Found" /tmp/packages.yaml
-    )
-}
-
 download_packages_yaml() {
     # $1: spack target
     . "${install_path}/share/spack/setup-env.sh"


### PR DESCRIPTION
New option `--buildcache` added. The default is `true` for Alinux2 and `false` for all other OSs. The buildcaches are currently only built for Alinux2.

These buildcaches are created by the stacks under
`$SPACK_ROOT/share/spack/gitlab/cloud_pipelines/stacks/aws-pcluster-{x86_64_v4,neoverse_v1}/spack.yaml`. If those caches should be used, the local spack installation needs to be set up exactly as in the Spack gitlab build pipelines. This achieved using `$SPACK_ROOT/share/spack/gitlab/cloud_pipelines/scripts/pcluster/setup-pcluster.sh`.

Most of this commit deals with making sure `setup-pcluster.sh` can be used as a drop-in replacement for some of the functions called in `postinstall.sh`.