### PR TITLE
spack configuration for spack v0.22 build on Perlmutter

### DIFF
--- a/NERSC/perlmutter/spack-v0.22/cuda/spack.yaml
+++ b/NERSC/perlmutter/spack-v0.22/cuda/spack.yaml
@@ -1,0 +1,63 @@
+spack:
+  view: false
+  include:
+  - /global/common/software/spackecp/perlmutter/spack_settings/compilers.yaml
+  - /global/common/software/spackecp/perlmutter/spack_settings/packages.yaml
+  config:
+    concretization: separately
+    build_stage: $spack/var/spack/stage
+    misc_cache: $spack/var/spack/misc_cache
+    concretizer: clingo
+    install_tree:
+      padded_length: 128
+  concretizer:
+    reuse: true
+    unify: false
+  mirrors:
+    perlmutter-v0.22: file:///global/common/software/spackecp/mirrors/perlmutter-v0.22
+  ci:
+    enable-artifacts-buildcache: false
+    rebuild-index: true
+    target: gitlab
+    pipeline-gen:
+    - submapping:
+      - match: [os=sles15]
+        build-job:
+          tags: [perlmutter-e4s]
+      match_behavior: first
+    - any-job:
+        before_script:
+        - git clone -c feature.manyFiles=true -b releases/v0.22 $SPACK_REPO        
+        - . spack/share/spack/setup-env.sh
+        - which spack
+        - spack --version
+    - build-job:
+        tags: [perlmutter-e4s]
+        before_script:
+        - module reset
+        - module load cpu cray-pmi        
+        - module list
+        - source setup-env.sh
+        - git clone -c feature.manyFiles=true -b releases/v0.22 $SPACK_REPO
+        - . spack/share/spack/setup-env.sh
+        - which spack
+        - spack --version
+        - spack-python --path
+        script:
+        - spack env activate --without-view -d ${SPACK_CONCRETE_ENV_DIR}
+        - spack env st
+        - export SPACK_GNUPGHOME=$HOME/.gnupg
+        - spack gpg list
+        - spack -d ci rebuild
+    - reindex-job:
+        tags: [perlmutter-e4s]
+        script:
+        - echo "End Pipeline"
+    - noop-job:
+        tags: [perlmutter-e4s]
+        script:
+        - echo "End Pipeline"
+  specs:
+  - matrix:
+    - [$cuda_specs]
+    - [$gcc_compilers]  

--- a/NERSC/perlmutter/spack-v0.22/definitions.yaml
+++ b/NERSC/perlmutter/spack-v0.22/definitions.yaml
@@ -1,0 +1,85 @@
+  
+  definitions:
+  - gcc_compilers: ['%gcc@=12.3.0']
+  - gcc_specs:
+    - adios2
+    - amrex        
+    - boost
+    - butterflypack    
+    - caliper    
+    - datatransferkit    
+    - fortrilinos
+    - gasnet     
+    - h5bench
+    - hdf5
+    - heffte +fftw
+    - hpctoolkit
+    - hpx max_cpu_count=512 networking=mpi
+    - hypre
+    - kokkos +openmp
+    - kokkos-kernels +openmp        
+    - likwid    
+    - mercury    
+    - mfem
+    - nccmp
+    - nco
+    - netlib-scalapack    
+    - openpmd-api
+    - papi    
+    - pdt
+    - petsc
+    - phist
+    - plasma
+    - plumed    
+    - py-h5py        
+    - py-petsc4py
+    - qthreads scheduler=distrib
+    - slate ~cuda
+    - slepc    
+    - strumpack ~slate
+    - swig
+    - sundials
+    - superlu
+    - superlu-dist            
+    - tau +mpi +python
+    - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long        
+    - upcxx        
+
+  - cuda_specs:
+    - amrex +cuda cuda_arch=80
+    - heffte +cuda cuda_arch=80
+    - hypre +cuda cuda_arch=80
+    - kokkos +wrapper +cuda cuda_arch=80
+    - kokkos-kernels +cuda cuda_arch=80 ^kokkos +wrapper +cuda cuda_arch=80
+    - magma +cuda cuda_arch=80
+    - petsc +cuda cuda_arch=80
+    - slate +cuda cuda_arch=80
+    - slepc +cuda cuda_arch=80
+    - strumpack ~slate +cuda cuda_arch=80
+    - sundials +cuda cuda_arch=80
+    - superlu-dist +cuda cuda_arch=80 
+
+  - nersc_specs:
+    - chapel
+    - gsl    
+    - netcdf-c ~mpi 
+    - netcdf-fortran
+    - metis
+    - parmetis
+    - gromacs
+    - cdo
+    - ncl 
+    - nco
+    - ncview
+    - libxc
+    - libcint
+    - libint tune=molgw-lmax-7
+
+  - tools:
+    - autoconf
+    - automake
+    - cmake
+    - git
+    - gmake
+    - gawk
+    - nano

--- a/NERSC/perlmutter/spack-v0.22/gcc/spack.yaml
+++ b/NERSC/perlmutter/spack-v0.22/gcc/spack.yaml
@@ -1,0 +1,69 @@
+spack:
+  view: false
+  include:
+  - /global/common/software/spackecp/perlmutter/spack_settings/compilers.yaml
+  - /global/common/software/spackecp/perlmutter/spack_settings/packages.yaml
+  config:
+    concretization: separately
+    build_stage: $spack/var/spack/stage
+    misc_cache: $spack/var/spack/misc_cache
+    concretizer: clingo
+    install_tree:
+      padded_length: 128
+  concretizer:
+    reuse: true
+    unify: false
+  mirrors:
+    perlmutter-v0.22: file:///global/common/software/spackecp/mirrors/perlmutter-v0.22
+  ci:
+    enable-artifacts-buildcache: false
+    rebuild-index: true
+    target: gitlab
+    pipeline-gen:
+    - submapping:
+      - match: [os=sles15]
+        build-job:
+          tags: [perlmutter-e4s]
+      match_behavior: first
+    - any-job:
+        before_script:
+        - git clone -c feature.manyFiles=true -b releases/v0.22 $SPACK_REPO        
+        - . spack/share/spack/setup-env.sh
+        - which spack
+        - spack --version
+    - build-job:
+        tags: [perlmutter-e4s]
+        before_script:
+        - module reset
+        - module load cpu cray-pmi        
+        - module list
+        - source setup-env.sh
+        - git clone -c feature.manyFiles=true -b releases/v0.22 $SPACK_REPO
+        - . spack/share/spack/setup-env.sh
+        - which spack
+        - spack --version
+        - spack-python --path
+        script:
+        - spack env activate --without-view -d ${SPACK_CONCRETE_ENV_DIR}
+        - spack env st
+        - export SPACK_GNUPGHOME=$HOME/.gnupg
+        - spack gpg list
+        - spack -d ci rebuild
+    - reindex-job:
+        tags: [perlmutter-e4s]
+        script:
+        - echo "End Pipeline"
+    - noop-job:
+        tags: [perlmutter-e4s]
+        script:
+        - echo "End Pipeline"
+  specs:
+  - matrix:
+    - [$gcc_specs]
+    - [$gcc_compilers]
+  - matrix:
+    - [$nersc_specs]
+    - [$gcc_compilers]
+  - matrix:
+    - [$tools]
+    - [$gcc_compilers]

--- a/NERSC/perlmutter/spack-v0.22/prod/cuda/spack.yaml
+++ b/NERSC/perlmutter/spack-v0.22/prod/cuda/spack.yaml
@@ -1,0 +1,20 @@
+spack:
+  view: false
+  include:
+    - /global/common/software/spackecp/perlmutter/spack_settings/compilers.yaml
+    - /global/common/software/spackecp/perlmutter/spack_settings/packages.yaml
+  config:
+    concretization: separately
+    build_stage: $spack/var/spack/stage
+    misc_cache: $spack/var/spack/misc_cache
+    concretizer: clingo
+    install_tree: $spack/opt/spack
+  concretizer:
+    reuse: true
+    unify: false
+  mirrors:       
+    perlmutter-v0.22: file:///global/common/software/spackecp/mirrors/perlmutter-v0.22
+  specs:
+  - matrix:
+    - [$cuda_specs]
+    - [$gcc_compilers]

--- a/NERSC/perlmutter/spack-v0.22/prod/gcc/spack.yaml
+++ b/NERSC/perlmutter/spack-v0.22/prod/gcc/spack.yaml
@@ -1,0 +1,26 @@
+spack:
+  view: false
+  include:
+    - /global/common/software/spackecp/perlmutter/spack_settings/compilers.yaml
+    - /global/common/software/spackecp/perlmutter/spack_settings/packages.yaml
+  config:
+    concretization: separately
+    build_stage: $spack/var/spack/stage
+    misc_cache: $spack/var/spack/misc_cache
+    concretizer: clingo
+    install_tree: $spack/opt/spack
+  concretizer:
+    reuse: true
+    unify: false
+  mirrors:       
+    perlmutter-v0.22: file:///global/common/software/spackecp/mirrors/perlmutter-v0.22
+  specs:
+  - matrix:
+    - [$gcc_specs]
+    - [$gcc_compilers]
+  - matrix:
+    - [$nersc_specs]
+    - [$gcc_compilers]
+  - matrix:
+    - [$tools]
+    - [$gcc_compilers]

--- a/NERSC/settings/muller/compilers.yaml
+++ b/NERSC/settings/muller/compilers.yaml
@@ -1,31 +1,5 @@
 compilers:
   - compiler:
-      spec: gcc@7.5.0
-      paths:
-        cc: /usr/bin/gcc
-        cxx: /usr/bin/g++
-        f77: /usr/bin/gfortran
-        fc: /usr/bin/gfortran
-      flags: {}
-      operating_system: sles15
-      target: any
-      modules: []
-  - compiler:
-      spec: nvhpc@21.11
-      paths:
-        cc: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/bin/nvc
-        cxx: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/bin/nvc++
-        f77: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/bin/nvfortran
-        fc: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/bin/nvfortran
-      flags: {}
-      operating_system: sles15
-      target: any
-      modules:
-      - PrgEnv-nvhpc
-      - nvhpc/21.11
-      - craype-x86-milan
-      - libfabric
-  - compiler:
       spec: nvhpc@22.7
       paths:
         cc: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvc
@@ -53,6 +27,21 @@ compilers:
       modules:
       - PrgEnv-nvhpc
       - nvhpc/23.1
+      - craype-x86-milan
+      - libfabric
+  - compiler:
+      spec: nvhpc@23.9
+      paths:
+        cc: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/compilers/bin/nvc
+        cxx: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/compilers/bin/nvc++
+        f77: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/compilers/bin/nvfortran
+        fc: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/compilers/bin/nvfortran
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-nvhpc
+      - nvhpc/23.9
       - craype-x86-milan
       - libfabric
   - compiler:
@@ -88,7 +77,7 @@ compilers:
       - libfabric
       extra_rpaths: []
   - compiler:
-      spec: gcc@12.2.0
+      spec: gcc@12.3.0
       paths:
         cc: /opt/cray/pe/craype/default/bin/cc
         cxx: /opt/cray/pe/craype/default/bin/CC
@@ -99,7 +88,7 @@ compilers:
       target: any
       modules:
       - PrgEnv-gnu
-      - gcc/12.2.0
+      - gcc-native/12.3
       - craype-x86-milan
       - libfabric
       extra_rpaths: []
@@ -139,3 +128,20 @@ compilers:
       environment: {}
       extra_rpaths: []
 
+  - compiler:
+      spec: cce@17.0.0
+      paths:
+        cc: /opt/cray/pe/craype/default/bin/cc
+        cxx: /opt/cray/pe/craype/default/bin/CC
+        f77: /opt/cray/pe/craype/default/bin/ftn
+        fc: /opt/cray/pe/craype/default/bin/ftn
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-cray
+      - cce/17.0.0
+      - craype-x86-milan
+      - libfabric
+      environment: {}
+      extra_rpaths: []

--- a/NERSC/settings/muller/packages.yaml
+++ b/NERSC/settings/muller/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler: [gcc@11.2.0, nvhpc@22.7, cce@15.0.0]
+    compiler: [gcc@12.3.0, nvhpc@23.9, cce@17.0.0]
     providers:
       blas: [cray-libsci]
       mpi: [cray-mpich]
@@ -16,56 +16,53 @@ packages:
   cray-libsci:
     buildable: false
     externals:
-    - spec: cray-libsci@os %gcc
+    - spec: cray-libsci@os %gcc@12.3.0
       modules: [cray-libsci]
-      prefix: /opt/cray/pe/libsci/default/GNU/9.1/x86_64
-    - spec: cray-libsci@os %nvhpc
+      prefix: /opt/cray/pe/libsci/default/gnu/12.3/x86_64
+    - spec: cray-libsci@os %nvhpc@23.9
       modules: [cray-libsci]
-      prefix: /opt/cray/pe/libsci/default/NVIDIA/20.7/x86_64
-    - spec: cray-libsci@os %cce
+      prefix: /opt/cray/pe/libsci/default/nvidia/23.3/x86_64
+    - spec: cray-libsci@os %cce@17.0.0
       modules: [cray-libsci]
-      prefix: /opt/cray/pe/libsci/default/CRAY/9.0/x86_64
+      prefix: /opt/cray/pe/libsci/default/cray/17.0/x86_64
   cray-mpich:
     buildable: false
     externals:
-    - spec: cray-mpich@os %gcc@11.2.0
-      prefix: /opt/cray/pe/mpich/default/ofi/gnu/9.1
-      modules: [cray-mpich/8.1.25, cudatoolkit/11.7]
-    - spec: cray-mpich@os %nvhpc@22.7
-      prefix: /opt/cray/pe/mpich/default/ofi/nvidia/20.7
-      modules: [cray-mpich/8.1.25, cudatoolkit/11.7]
-    - spec: cray-mpich@os %cce@15.0.0
-      prefix: /opt/cray/pe/mpich/default/ofi/cray/10.0
-      modules:
-        - cray-mpich/8.1.25
-        - cudatoolkit/11.7
+    - spec: cray-mpich@os %gcc@12.3.0
+      prefix: /opt/cray/pe/mpich/8.1.28/ofi/gnu/12.3
+      modules: [cray-mpich/8.1.27, cudatoolkit/12.2]
+    - spec: cray-mpich@os %nvhpc@23.9
+      prefix: /opt/cray/pe/mpich/8.1.28/ofi/nvidia/23.3
+      modules: [cray-mpich/8.1.27, cudatoolkit/12.2]
+    - spec: cray-mpich@os %cce@17.0.0
+      prefix: /opt/cray/pe/mpich/8.1.28/ofi/cray/17.0
+      modules: [cray-mpich/8.1.27, cudatoolkit/12.2]
   cray-pmi:
     buildable: false
     externals:
-    - spec: cray-pmi@6.1.10
+    - spec: cray-pmi@6.1.13
       modules: [cray-pmi]
       prefix: /opt/cray/pe/pmi/default
   cuda:
     buildable: false
-    version: [11.7.0, 11.5.0]
+    version: [12.2.0, 11.7.0]
     externals:
+    - spec: cuda@12.2.0  
+      prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/cuda/12.2
+      modules: [cudatoolkit/12.2]
     - spec: cuda@11.7.0
       prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/cuda/11.7
-      modules: [cudatoolkit/11.7]
-    - spec: cuda@11.5.0
-      prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/cuda/11.5
-      modules: [cudatoolkit/11.5]
+      modules: [cudatoolkit/11.7]    
   cub:
     buildable: false
     externals:
+    - spec: cub@2.0.1
+      prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/cuda/12.2/targets/x86_64-linux
+      modules: [cudatoolkit/12.2]
     # see https://docs.nvidia.com/hpc-sdk/archive/22.7/hpc-sdk-release-notes/index.html
     - spec: cub@1.15.0
       prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/cuda/11.7/targets/x86_64-linux
       modules: [cudatoolkit/11.7]
-    # see release notes for CUB version https://docs.nvidia.com/hpc-sdk/archive/21.11/hpc-sdk-release-notes/index.html
-    - spec: cub@1.13.1
-      prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/cuda/11.5/targets/x86_64-linux
-      modules: [cudatoolkit/11.5]
   curl:
     buildable: false
     externals:

--- a/NERSC/settings/perlmutter/compilers.yaml
+++ b/NERSC/settings/perlmutter/compilers.yaml
@@ -1,31 +1,5 @@
 compilers:
   - compiler:
-      spec: gcc@7.5.0
-      paths:
-        cc: /usr/bin/gcc
-        cxx: /usr/bin/g++
-        f77: /usr/bin/gfortran
-        fc: /usr/bin/gfortran
-      flags: {}
-      operating_system: sles15
-      target: any
-      modules: []
-  - compiler:
-      spec: nvhpc@21.11
-      paths:
-        cc: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/bin/nvc
-        cxx: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/bin/nvc++
-        f77: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/bin/nvfortran
-        fc: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/bin/nvfortran
-      flags: {}
-      operating_system: sles15
-      target: any
-      modules:
-      - PrgEnv-nvhpc
-      - nvhpc/21.11
-      - craype-x86-milan
-      - libfabric
-  - compiler:
       spec: nvhpc@22.7
       paths:
         cc: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvc
@@ -53,6 +27,21 @@ compilers:
       modules:
       - PrgEnv-nvhpc
       - nvhpc/23.1
+      - craype-x86-milan
+      - libfabric
+  - compiler:
+      spec: nvhpc@23.9
+      paths:
+        cc: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/compilers/bin/nvc
+        cxx: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/compilers/bin/nvc++
+        f77: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/compilers/bin/nvfortran
+        fc: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/compilers/bin/nvfortran
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-nvhpc
+      - nvhpc/23.9
       - craype-x86-milan
       - libfabric
   - compiler:
@@ -88,7 +77,7 @@ compilers:
       - libfabric
       extra_rpaths: []
   - compiler:
-      spec: gcc@12.2.0
+      spec: gcc@12.3.0
       paths:
         cc: /opt/cray/pe/craype/default/bin/cc
         cxx: /opt/cray/pe/craype/default/bin/CC
@@ -99,7 +88,7 @@ compilers:
       target: any
       modules:
       - PrgEnv-gnu
-      - gcc/12.2.0
+      - gcc-native/12.3
       - craype-x86-milan
       - libfabric
       extra_rpaths: []
@@ -139,3 +128,20 @@ compilers:
       environment: {}
       extra_rpaths: []
 
+  - compiler:
+      spec: cce@17.0.0
+      paths:
+        cc: /opt/cray/pe/craype/default/bin/cc
+        cxx: /opt/cray/pe/craype/default/bin/CC
+        f77: /opt/cray/pe/craype/default/bin/ftn
+        fc: /opt/cray/pe/craype/default/bin/ftn
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-cray
+      - cce/17.0.0
+      - craype-x86-milan
+      - libfabric
+      environment: {}
+      extra_rpaths: []

--- a/NERSC/settings/perlmutter/packages.yaml
+++ b/NERSC/settings/perlmutter/packages.yaml
@@ -1,6 +1,6 @@
 packages:
   all:
-    compiler: [gcc@11.2.0, nvhpc@22.7, cce@15.0.0]
+    compiler: [gcc@12.3.0, nvhpc@23.9, cce@17.0.0]
     providers:
       blas: [cray-libsci]
       mpi: [cray-mpich]
@@ -16,56 +16,53 @@ packages:
   cray-libsci:
     buildable: false
     externals:
-    - spec: cray-libsci@os %gcc
+    - spec: cray-libsci@os %gcc@12.3.0
       modules: [cray-libsci]
-      prefix: /opt/cray/pe/libsci/default/GNU/9.1/x86_64
-    - spec: cray-libsci@os %nvhpc
+      prefix: /opt/cray/pe/libsci/default/gnu/12.3/x86_64
+    - spec: cray-libsci@os %nvhpc@23.9
       modules: [cray-libsci]
-      prefix: /opt/cray/pe/libsci/default/NVIDIA/20.7/x86_64
-    - spec: cray-libsci@os %cce
+      prefix: /opt/cray/pe/libsci/default/nvidia/23.3/x86_64
+    - spec: cray-libsci@os %cce@17.0.0
       modules: [cray-libsci]
-      prefix: /opt/cray/pe/libsci/default/CRAY/9.0/x86_64
+      prefix: /opt/cray/pe/libsci/default/cray/17.0/x86_64
   cray-mpich:
     buildable: false
     externals:
-    - spec: cray-mpich@os %gcc@11.2.0
-      prefix: /opt/cray/pe/mpich/default/ofi/gnu/9.1
-      modules: [cray-mpich/8.1.25, cudatoolkit/11.7]
-    - spec: cray-mpich@os %nvhpc@22.7
-      prefix: /opt/cray/pe/mpich/default/ofi/nvidia/20.7
-      modules: [cray-mpich/8.1.25, cudatoolkit/11.7]
-    - spec: cray-mpich@os %cce@15.0.0
-      prefix: /opt/cray/pe/mpich/default/ofi/cray/10.0
-      modules:
-        - cray-mpich/8.1.25
-        - cudatoolkit/11.7
+    - spec: cray-mpich@os %gcc@12.3.0
+      prefix: /opt/cray/pe/mpich/8.1.28/ofi/gnu/12.3
+      modules: [cray-mpich/8.1.27, cudatoolkit/12.2]
+    - spec: cray-mpich@os %nvhpc@23.9
+      prefix: /opt/cray/pe/mpich/8.1.28/ofi/nvidia/23.3
+      modules: [cray-mpich/8.1.27, cudatoolkit/12.2]
+    - spec: cray-mpich@os %cce@17.0.0
+      prefix: /opt/cray/pe/mpich/8.1.28/ofi/cray/17.0
+      modules: [cray-mpich/8.1.27, cudatoolkit/12.2]
   cray-pmi:
     buildable: false
     externals:
-    - spec: cray-pmi@6.1.10
+    - spec: cray-pmi@6.1.13
       modules: [cray-pmi]
       prefix: /opt/cray/pe/pmi/default
   cuda:
     buildable: false
-    version: [11.7.0, 11.5.0]
+    version: [12.2.0, 11.7.0]
     externals:
+    - spec: cuda@12.2.0  
+      prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/cuda/12.2
+      modules: [cudatoolkit/12.2]
     - spec: cuda@11.7.0
       prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/cuda/11.7
-      modules: [cudatoolkit/11.7]
-    - spec: cuda@11.5.0
-      prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/cuda/11.5
-      modules: [cudatoolkit/11.5]
+      modules: [cudatoolkit/11.7]    
   cub:
     buildable: false
     externals:
+    - spec: cub@2.0.1
+      prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/23.9/cuda/12.2/targets/x86_64-linux
+      modules: [cudatoolkit/12.2]
     # see https://docs.nvidia.com/hpc-sdk/archive/22.7/hpc-sdk-release-notes/index.html
     - spec: cub@1.15.0
       prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/cuda/11.7/targets/x86_64-linux
       modules: [cudatoolkit/11.7]
-    # see release notes for CUB version https://docs.nvidia.com/hpc-sdk/archive/21.11/hpc-sdk-release-notes/index.html
-    - spec: cub@1.13.1
-      prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/cuda/11.5/targets/x86_64-linux
-      modules: [cudatoolkit/11.5]
   curl:
     buildable: false
     externals:


### PR DESCRIPTION
@wspear and @eugeneswalker just a heads up we have built spack v0.22 on Perlmutter its not based on e4s-24.05 branch but slightly higher since v0.22 was released after the e4s release. I am sharing the spack configuration here in case it makes sense you want me to update the E4S dashboard (https://e4s.readthedocs.io/en/latest/facility_e4s.html)