### PR TITLE
[AWS] Remove some ParallelCluster specific assumption to enable AWS Parallel Computing Service

### DIFF
--- a/AWS/parallelcluster/packages-icelake.yaml
+++ b/AWS/parallelcluster/packages-icelake.yaml
@@ -57,7 +57,7 @@ packages:
   slurm:
     buildable: false
     externals:
-      - prefix: /opt/slurm/
+      - prefix: ${SLURM_ROOT}
         spec: slurm@${SLURM_VERSION} +pmix
   wrf:
     require:

--- a/AWS/parallelcluster/packages-neoverse_n1.yaml
+++ b/AWS/parallelcluster/packages-neoverse_n1.yaml
@@ -51,7 +51,7 @@ packages:
   slurm:
     buildable: false
     externals:
-      - prefix: /opt/slurm/
+      - prefix: ${SLURM_ROOT}
         spec: slurm@${SLURM_VERSION} +pmix
   all:
     compiler: [gcc, arm, nvhpc, clang]

--- a/AWS/parallelcluster/packages-neoverse_v1.yaml
+++ b/AWS/parallelcluster/packages-neoverse_v1.yaml
@@ -44,7 +44,7 @@ packages:
   slurm:
     buildable: false
     externals:
-      - prefix: /opt/slurm/
+      - prefix: ${SLURM_ROOT}
         spec: slurm@${SLURM_VERSION} +pmix
   wrf:
     require:

--- a/AWS/parallelcluster/packages-skylake_avx512.yaml
+++ b/AWS/parallelcluster/packages-skylake_avx512.yaml
@@ -57,7 +57,7 @@ packages:
   slurm:
     buildable: false
     externals:
-      - prefix: /opt/slurm/
+      - prefix: ${SLURM_ROOT}
         spec: slurm@${SLURM_VERSION} +pmix
   wrf:
     require:

--- a/AWS/parallelcluster/packages-zen2.yaml
+++ b/AWS/parallelcluster/packages-zen2.yaml
@@ -62,7 +62,7 @@ packages:
   slurm:
     buildable: false
     externals:
-      - prefix: /opt/slurm/
+      - prefix: ${SLURM_ROOT}
         spec: slurm@${SLURM_VERSION} +pmix
   stream:
     require:

--- a/AWS/parallelcluster/postinstall.sh
+++ b/AWS/parallelcluster/postinstall.sh
@@ -504,7 +504,7 @@ install_packages() {
     done
 }
 
-if [ "3" != "$(major_version)" ]; then
+if [ -f "/opt/parallelcluster/.bootstrapped" ] && [ "3" != "$(major_version)" ]; then
     echo "ParallelCluster version $(major_version) not supported."
     exit 1
 fi

--- a/AWS/parallelcluster/postinstall.sh
+++ b/AWS/parallelcluster/postinstall.sh
@@ -142,14 +142,6 @@ setup_variables() {
     cluster_config="/opt/parallelcluster/shared/cluster-config.yaml"
     pip3 install pyyaml
     if [ -f "${cluster_config}" ]; then
-        os=$(python3 << EOF
-#/usr/bin/env python
-import yaml
-with open("${cluster_config}", 'r') as s:
-    print(yaml.safe_load(s)["Image"]["Os"])
-EOF
-          )
-
         cfn_ebs_shared_dirs=$(python3 << EOF
 #/usr/bin/env python
 import yaml
@@ -185,10 +177,10 @@ EOF
     install_path=${SPACK_ROOT:-"${cfn_ebs_shared_dirs}/spack"}
     echo "Installing Spack into ${install_path}."
 
-    if [ "true" == "${generic_buildcache}" ] && [ "alinux2" != "${os}" ]; then
+    if [ "true" == "${generic_buildcache}" ] && [ "Amazon Linux 2" != "${PRETTY_NAME}" ]; then
         echo "Generic buildcache only available for Alinux2."
     fi
-    if [ -z "${generic_buildcache}" ] && [ "alinux2" == "${os}" ]; then
+    if [ -z "${generic_buildcache}" ] && [ "Amazon Linux 2" == "${PRETTY_NAME}" ]; then
         generic_buildcache=true
     else
         generic_buildcache=false

--- a/AWS/parallelcluster/postinstall.sh
+++ b/AWS/parallelcluster/postinstall.sh
@@ -175,8 +175,7 @@ EOF
 
     # Use external Spack if $SPACK_ROOT is already set
     install_path=${SPACK_ROOT:-"${cfn_ebs_shared_dirs}/spack"}
-    tmp_path="${cfn_ebs_shared_dirs}/tmp"
-    mkdir -p "${tmp_path}" && export TMPDIR="${tmp_path}"
+    tmp_path="$(mktemp -d -p "${cfn_ebs_shared_dirs}")" && export TMPDIR="${tmp_path}"
 
     echo "Installing Spack into ${install_path}."
 
@@ -203,7 +202,7 @@ cleanup() {
     then
         chown -R ${default_user}:${default_user} "${install_path}"
     fi
-    rm -rf "${tmp_path}"
+    [ -d "${tmp_path}" ] && rm -rf "${tmp_path}"
     exit $rc
 }
 

--- a/AWS/parallelcluster/postinstall.sh
+++ b/AWS/parallelcluster/postinstall.sh
@@ -125,10 +125,18 @@ done
 
 setup_variables() {
     # Determine default user
-    for default_user in ec2-user centos rocky ubuntu; do
-        grep -q "${default_user}" /etc/shadow && break
-        default_user=""
-    done
+    [ -f /etc/os-release ] && . /etc/os-release
+    case "$ID" in
+        amzn|rhel)
+            default_user="ec2-user"
+            ;;
+        centos|ubuntu|rocky)
+            default_user="${ID}"
+            ;;
+        *)
+            default_user=""
+            ;;
+    esac
 
     # Install onto first shared storage device
     cluster_config="/opt/parallelcluster/shared/cluster-config.yaml"

--- a/AWS/parallelcluster/postinstall.sh
+++ b/AWS/parallelcluster/postinstall.sh
@@ -282,9 +282,10 @@ set_modules() {
 
 set_pcluster_defaults() {
     # Set versions of pre-installed software in packages.yaml
-    [ -z "${SLURM_VERSION}" ] && SLURM_VERSION=$(strings /opt/slurm/lib/libslurm.so | grep  -e '^VERSION'  | awk '{print $2}'  | sed -e 's?"??g')
+    [ -z "${SLURM_ROOT}" ] && SLURM_ROOT=$(dirname $(dirname "$(awk '/ExecStart=/ {print $1}' /etc/systemd/system/slurm* | sed -e 's?^.*=??1' | head -n1)"))
+    [ -z "${SLURM_VERSION}" ] && SLURM_VERSION=$("${SLURM_ROOT}/sinfo" --version | cut -d\  -f2)
     [ -z "${LIBFABRIC_VERSION}" ] && LIBFABRIC_VERSION=$(awk '/Version:/{print $2}' "$(find /opt/amazon/efa/ -name libfabric.pc | head -n1)" | sed -e 's?~??g' -e 's?amzn.*??g')
-    export SLURM_VERSION LIBFABRIC_VERSION
+    export SLURM_VERSION SLURM_ROOT LIBFABRIC_VERSION
 
     # Write the above as actual yaml file and only parse the \$.
     mkdir -p "${install_path}/etc/spack"

--- a/AWS/parallelcluster/postinstall.sh
+++ b/AWS/parallelcluster/postinstall.sh
@@ -278,9 +278,8 @@ set_modules() {
 set_variables() {
     # Set versions of pre-installed software in packages.yaml
     [ -z "${SLURM_ROOT}" ] && SLURM_ROOT=$(dirname $(dirname "$(awk '/ExecStart=/ {print $1}' /etc/systemd/system/slurm* | sed -e 's?^.*=??1' | head -n1)"))
-    [ -z "${SLURM_VERSION}" ] && SLURM_VERSION=$("${SLURM_ROOT}/bin/sinfo" --version | cut -d\  -f2)
     # Fallback to default location if SLURM not in systemd
-    [ -z "${SLURM_VERSION}" ] && SLURM_VERSION=$(strings /opt/slurm/lib/libslurm.so | grep  -e '^VERSION'  | awk '{print $2}'  | sed -e 's?"??g')
+    [ -z "${SLURM_VERSION}" ] && SLURM_VERSION=$(strings "${SLURM_ROOT:-/opt/slurm}"/lib/libslurm.so | grep -e '^VERSION' | awk '{print $2}' | sed -e 's?"??g')
     [ -z "${LIBFABRIC_VERSION}" ] && LIBFABRIC_VERSION=$(awk '/Version:/{print $2}' "$(find /opt/amazon/efa/ -name libfabric.pc | head -n1)" | sed -e 's?~??g' -e 's?amzn.*??g')
     export SLURM_VERSION SLURM_ROOT LIBFABRIC_VERSION
 }

--- a/AWS/parallelcluster/postinstall.sh
+++ b/AWS/parallelcluster/postinstall.sh
@@ -275,7 +275,7 @@ set_modules() {
 set_pcluster_defaults() {
     # Set versions of pre-installed software in packages.yaml
     [ -z "${SLURM_ROOT}" ] && SLURM_ROOT=$(dirname $(dirname "$(awk '/ExecStart=/ {print $1}' /etc/systemd/system/slurm* | sed -e 's?^.*=??1' | head -n1)"))
-    [ -z "${SLURM_VERSION}" ] && SLURM_VERSION=$("${SLURM_ROOT}/sinfo" --version | cut -d\  -f2)
+    [ -z "${SLURM_VERSION}" ] && SLURM_VERSION=$("${SLURM_ROOT}/bin/sinfo" --version | cut -d\  -f2)
     [ -z "${LIBFABRIC_VERSION}" ] && LIBFABRIC_VERSION=$(awk '/Version:/{print $2}' "$(find /opt/amazon/efa/ -name libfabric.pc | head -n1)" | sed -e 's?~??g' -e 's?amzn.*??g')
     export SLURM_VERSION SLURM_ROOT LIBFABRIC_VERSION
 


### PR DESCRIPTION
Various changes which do not change the bahvior on standard ParallelCluster, but enable this script on PCS which has a few different assumptions. In detail:

- Added optional `--prefix` to overwrite the install location found.
- Do not assume SLURM is always installed into `/opt/slurm`. SLURM startup scripts can be found in `/etc/systemd`.
- Check for default user by reading `/etc/os-release`
- If no ParallelCluster configuration file is found look for a mounted Lustre, EFS and NFS share before turning to `$HOME` as installation location.
